### PR TITLE
DuckDuckGo now makes POST requests for search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased](https://github.com/prem-k-r/MaterialYouNewTab/compare/v3.2...main)
 
 ### Improved
-
 - Updated search suggestion behavior to autocomplete the current search term upon selection via keyboard ([@prem-k-r](https://github.com/prem-k-r)), ([@itz-rj-here](https://github.com/itz-rj-here)) ([#33](https://github.com/prem-k-r/MaterialYouNewTab/pull/33))
 
 ### Localized
@@ -65,7 +64,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added edit functionality for todo list ([@GauravKukreti](https://github.com/GauravKukreti)) ([#719](https://github.com/XengShi/materialYouNewTab/pull/719))
 
 ### Changed
-
+- DuckDuckGo now makes POST requests for search instead of GET requests ([@spj2401Dev](https://github.com/spj2401Dev))
 - Weather retention time set to 7.25 minutes for user-entered API keys and 16 minutes otherwise ([@prem-k-r](https://github.com/prem-k-r)) ([#428](https://github.com/XengShi/materialYouNewTab/pull/428))
 - Changed default Vietnamese font to 'Be Vietnam Pro' ([@prem-k-r](https://github.com/prem-k-r)) ([#442](https://github.com/XengShi/materialYouNewTab/pull/442))
 - Improved date format for Japanese and Korean ([@prem-k-r](https://github.com/prem-k-r)), ([@dempavof](https://github.com/dempavof)) ([#529](https://github.com/XengShi/materialYouNewTab/pull/529))

--- a/scripts/search.js
+++ b/scripts/search.js
@@ -249,7 +249,9 @@ function submitPostSearch(config, searchTerm) {
 
     document.body.appendChild(form);
     form.submit();
-    document.body.removeChild(form);
+    setTimeout(() => {
+        document.body.removeChild(form);
+    }, 0);
 }
 
 // Event listeners

--- a/scripts/search.js
+++ b/scripts/search.js
@@ -22,6 +22,12 @@ const searchQueryURLs = {
     engine9: "https://www.quora.com/search?q="
 };
 
+// DDG supports POST requests
+const duckDuckGoConfig = {
+    url: "https://duckduckgo.com/",
+    param: "q"
+};
+
 // Showing border or outline when you click on the searchbar
 searchbar.addEventListener("click", function (event) {
     event.stopPropagation();
@@ -218,11 +224,32 @@ function performSearch(query) {
                 var fallbackUrl = searchQueryURLs.engine1 + encodeURIComponent(searchTerm);
                 window.location.href = fallbackUrl;
             }
+        } else if (selectedOption === "engine2") {
+            // POST request for DDG
+            submitPostSearch(duckDuckGoConfig, searchTerm);
         } else {
+            // GET request for all other search engines
             var searchUrl = searchQueryURLs[selectedOption] + encodeURIComponent(searchTerm);
             window.location.href = searchUrl;
         }
     }
+}
+
+function submitPostSearch(config, searchTerm) {
+    const form = document.createElement("form");
+    form.method = "POST";
+    form.action = config.url;
+    form.style.display = "none";
+
+    const searchInput = document.createElement("input");
+    searchInput.type = "hidden";
+    searchInput.name = config.param;
+    searchInput.value = searchTerm;
+    form.appendChild(searchInput);
+
+    document.body.appendChild(form);
+    form.submit();
+    document.body.removeChild(form);
 }
 
 // Event listeners


### PR DESCRIPTION
## 📌 Description

Using this the Search button will use a POST request to search for DuckDuckGo. 
The issue like described cannot be implemented as is to my knowlage as Google, Bing, etc... does not support POST requests

## 🎨 Visual Changes (Screenshots / Videos)

No visual changes made

## 🔗 Related Issues

Related to #60
This will probably need some discussing

## ✅ Checklist

- [X] I have read and followed the [Contributing Guidelines](https://github.com/prem-k-r/materialYouNewTab/blob/main/CONTRIBUTING.md).
- [X] My code follows the project's coding style and conventions.
- [X] I have tested my changes thoroughly to ensure expected behavior.
- [X] I have verified compatibility across Chrome and Firefox (additional browsers if applicable).
- [X] I have attached relevant visual evidence (screenshots/videos) if applicable.
- [X (at least I hope I did it correctly)] I have updated the [CHANGELOG.md](https://github.com/prem-k-r/materialYouNewTab/blob/main/CHANGELOG.md) under the appropriate categories with all my changes in this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changed**
  * DuckDuckGo search queries now submitted via POST requests instead of GET requests.
  * Other search engines continue to operate as before.

* **Documentation**
  * Updated changelog to reflect DuckDuckGo search method modification.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->