### PR TITLE
Added search box hide button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added toggle to hide or show location in the location tile ([@prem-k-r](https://github.com/prem-k-r)) ([#685](https://github.com/XengShi/materialYouNewTab/pull/685))
 - Added drag and drop functionality for reordering shortcuts ([@prem-k-r](https://github.com/prem-k-r)) ([#695](https://github.com/XengShi/materialYouNewTab/pull/695))
 - Added edit functionality for todo list ([@GauravKukreti](https://github.com/GauravKukreti)) ([#719](https://github.com/XengShi/materialYouNewTab/pull/719))
+- Added option to hide the search box ([@satyansh2004](https://github.com/satyansh2004)) ([#51](https://github.com/prem-k-r/MaterialYouNewTab/issues/51))
 
 ### Changed
 

--- a/index.html
+++ b/index.html
@@ -670,7 +670,7 @@
             <!-- ------end of weather stuff------------ -->
 
             <!-- ----------searchbar-------------- -->
-            <div class="searchbar bgLightTint" id="searchbar">
+            <div class="searchbar bgLightTint" id="searchbar" style="visibility: visible;">
 
                 <div class="searchIcon">
                     <svg fill="none" height="100%" viewBox="0 0 45 45" width="100%" xmlns="http://www.w3.org/2000/svg">
@@ -1472,6 +1472,17 @@
                                         </div>
                                         <label class="switch">
                                             <input id="shortcut_switchcheckbox" type="checkbox">
+                                            <span class="toggle"></span>
+                                        </label>
+                                    </div>
+
+                                    <div class="ttcont">
+                                        <div class="texts">
+                                            <div class="bigText" id="hideSearchBox">Hide Search Box</div>
+                                            <div class="infoText" id="hideSearchBoxInfo">If you do not want search box</div>
+                                        </div>
+                                        <label class="switch">
+                                            <input id="searchBoxCheckBox" type="checkbox">
                                             <span class="toggle"></span>
                                         </label>
                                     </div>

--- a/scripts/search.js
+++ b/scripts/search.js
@@ -414,3 +414,43 @@ document.addEventListener("keydown", function (event) {
         searchbar.classList.add("active");
     }
 });
+
+
+/* ------ Event Listeners for Searchbar ------ */
+const showSearchbar = () => {
+    document.getElementById("searchbar").style.visibility = "visible";
+}
+
+const hideSearchbar = () => {
+    document.getElementById("searchbar").style.visibility = "hidden";
+}
+
+const initSearchBarswitch = (element) => {
+    if (element.checked) {
+        hideSearchbar();
+        localStorage.setItem("showSearchBarswitch", true);
+    } else {
+        showSearchbar();
+        localStorage.setItem("showSearchBarswitch", false);
+    }
+}
+
+const hideSearchBox = document.getElementById("searchBoxCheckBox");
+hideSearchBox.addEventListener("change", (e) => {
+    initSearchBarswitch(e.target);
+});
+
+if (localStorage.getItem("showSearchBarswitch")) {
+    const isSearchBarswitchEnabled = localStorage.getItem("showSearchBarswitch").toString() === "true";
+    document.getElementById("searchBoxCheckBox").checked = isSearchBarswitchEnabled;
+
+if (isSearchBarswitchEnabled) {
+        hideSearchbar();
+    } else if (!isShortCutSwitchEnabled) {
+        showSearchbar();
+    }
+} else {
+    localStorage.setItem("showSearchBarswitch", false);
+}
+
+initSearchBarswitch(hideSearchBox);


### PR DESCRIPTION
## 📌 Description

This PR adds a button to hide the search box, allowing users who don’t use the search feature to keep the interface clean and minimal.

---

## 🎨 Visual Changes (Screenshots / Videos)

<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/2ebc7d60-fb7c-4999-a73a-4445469a85bb" />

---

<img width="1358" height="610" alt="Screenshot 2026-01-14 162539" src="https://github.com/user-attachments/assets/90b07eb2-0536-4495-8563-7a531575dfbc" />


## 🔗 Related Issue

- Closes #51

---

## ✅ Checklist

- [x] I have read and followed the Contributing Guidelines.
- [x] My code follows the project's coding style and conventions.
- [x] I have tested my changes thoroughly to ensure expected behavior.
- [x] I have verified compatibility across Chrome and Firefox.
- [x] I have attached relevant visual evidence (screenshots/videos) if applicable.
- [x] I have updated the CHANGELOG.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR implements a feature to allow users to hide the search box via a toggle switch, addressing issue #51. The implementation includes changes to `index.html`, `scripts/search.js`, and `CHANGELOG.md`.

## Implementation Issues

**Critical Bug in search.js (Line 449):**
The initialization code contains a variable scope bug in the conditional logic:
```javascript
const isSearchBarswitchEnabled = localStorage.getItem("showSearchBarswitch").toString() === "true";
// ...
if (isSearchBarswitchEnabled) {
    hideSearchbar();
} else if (!isShortCutSwitchEnabled) {  // BUG: References wrong variable
    showSearchbar();
}
```
The condition should check `!isSearchBarswitchEnabled` instead of `!isShortCutSwitchEnabled`. This causes the searchbar visibility to depend on an unrelated shortcut switch state rather than its own state.

**Conflicting HTML Styling:**
In `index.html` (line 673), the searchbar container includes an inline style `visibility: visible;` which makes the element always visible regardless of JavaScript state changes. This directly conflicts with the JavaScript logic that attempts to control visibility using `visibility: hidden/visible`. The inline style will override the JavaScript's visibility toggles.

**Duplicate Code:**
The initialization logic for the search bar switch (approximately lines 420-456 in search.js) contains duplicate blocks, resulting in redundant execution of the same code at the end of the file.

**Missing UI Affordance:**
While a checkbox element with ID `searchBoxCheckBox` is referenced in the code, the PR description mentions adding a "hide button," but no visible button element is evident in the markup. The control appears to be a settings checkbox rather than a dedicated button interface.

## Additional Changes

- **CHANGELOG.md**: Correctly documents the new feature on line 110 under the "Added" section.
- **localStorage Integration**: The feature persists the user's preference via localStorage with the key `showSearchBarswitch`.
- **Helper Functions**: Two utility functions (`showSearchbar()` and `hideSearchbar()`) control visibility by manipulating the element's visibility style property.

## Recommendations for Review

1. Resolve the variable scope bug on line 449 by using the correct variable reference
2. Remove the conflicting inline `style="visibility: visible;"` from the searchbar div in index.html
3. Remove or refactor the duplicate initialization code
4. Verify the UI control (checkbox vs. button) matches the stated functionality and is appropriately labeled and discoverable

<!-- end of auto-generated comment: release notes by coderabbit.ai -->