### PR TITLE
First Issue Hide Clock Toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -1382,12 +1382,12 @@
                                 <div class="sectionInner">
                                     <div class="ttcont" id="clockHidden">
                                         <div class="texts">
-                                            <div class="bigText" id="hideClockBox">Hide Clock</div>
+                                            <div class="bigText" id="hideClockBox">Show Clock</div>
                                             <div class="infoText" id="hideClockBoxInfo">Show or hide the clock and date
                                             </div>
                                         </div>
                                         <label class="switch">
-                                            <input id="hideClock" type="checkbox">
+                                            <input id="showClock" type="checkbox">
                                             <span class="toggle"></span>
                                         </label>
                                     </div>

--- a/scripts/clock.js
+++ b/scripts/clock.js
@@ -17,7 +17,7 @@ let lastGreetingString = null;
 // Select elements
 const leftDiv = document.getElementById("leftDiv");
 const rightDiv = document.getElementById("rightDiv");
-const hideClockCheckbox = document.getElementById("hideClock");
+const showClockCheckbox = document.getElementById("showClock");
 const clockHidden = document.getElementById("clockHidden");
 const clockOptions = document.querySelector(".clockOptions");
 
@@ -38,37 +38,52 @@ function applyClockState(isHidden) {
 }
 
 function handleClockVisibility() {
+    if (localStorage.getItem("showClock") === null) {
+        localStorage.setItem("showClock", "true");
+    }
+
+    const isClockVisible = localStorage.getItem("showClock") !== "false";
+
     if (window.matchMedia("(max-width: 500px)").matches) {
-        initializeClock();
+        showClockCheckbox.checked = isClockVisible;
+        applyClockState(!isClockVisible);
+        toggleHideState(!isClockVisible);
+
+        if (isClockVisible) {
+            initializeClock();
+        }
 
         clockOptions.classList.remove("not-applicable");
         rightDiv.classList.remove("clock-padding-adjusted");
     }
     else {
-        // Retrieve saved state from localStorage
-        const isClockHidden = localStorage.getItem("hideClockVisible") === "true";
-        hideClockCheckbox.checked = isClockHidden;
+        showClockCheckbox.checked = isClockVisible;
 
         // Apply initial state
-        applyClockState(isClockHidden);
-        toggleHideState(isClockHidden);
+        applyClockState(!isClockVisible);
+        toggleHideState(!isClockVisible);
 
-        if (!isClockHidden) {
+        if (isClockVisible) {
             initializeClock();
         }
-
-        hideClockCheckbox.addEventListener("change", function () {
-            const isChecked = hideClockCheckbox.checked;
-            localStorage.setItem("hideClockVisible", isChecked);
-            applyClockState(isChecked);
-            toggleHideState(isChecked);
-
-            if (!isChecked) {
-                initializeClock();
-            }
-        });
     }
 }
+
+showClockCheckbox.addEventListener("change", function () {
+    const isChecked = showClockCheckbox.checked;
+    localStorage.setItem("showClock", isChecked);
+    applyClockState(!isChecked);
+    toggleHideState(!isChecked);
+
+    if (window.matchMedia("(max-width: 500px)").matches) {
+        clockOptions.classList.remove("not-applicable");
+        rightDiv.classList.remove("clock-padding-adjusted");
+    }
+
+    if (isChecked) {
+        initializeClock();
+    }
+});
 
 handleClockVisibility();
 // Update on window resize
@@ -468,6 +483,13 @@ async function initializeClock() {
     function displayClock() {
         const analogClock = document.getElementById("analogClock");
         const digitalClock = document.getElementById("digitalClock");
+        const showClock = localStorage.getItem("showClock") !== "false";
+
+        if (!showClock) {
+            analogClock.style.display = "none";
+            digitalClock.style.display = "none";
+            return;
+        }
 
         if (clocktype === "analog") {
             analogClock.style.display = "block";  // Show the analog clock


### PR DESCRIPTION
## 📌 Description

<!-- Please provide a clear and concise description of the changes introduced in this PR and their purpose. -->

## 🎨 Visual Changes (Screenshots / Videos)

<!-- If applicable, attach relevant screenshots or screen recordings showcasing the modifications. -->

## 🔗 Related Issues

- Closes #<issue_number> <!-- if this PR fixes an issue -->
- Related to #<issue_number> <!-- if applicable -->

## ✅ Checklist

<!-- Tip: To mark a checklist item as complete, replace [ ] with [x] -->

- [ ] I have read and followed the [Contributing Guidelines](https://github.com/prem-k-r/MaterialYouNewTab/blob/main/CONTRIBUTING.md).
- [ ] My code follows the project's coding style and conventions.
- [ ] I have tested my changes thoroughly to ensure expected behavior.
- [ ] I have verified compatibility across Chrome and Firefox (additional browsers if applicable).
- [ ] I have attached relevant visual evidence (screenshots/videos) if applicable.
- [ ] I have updated the [CHANGELOG.md](https://github.com/prem-k-r/MaterialYouNewTab/blob/main/CHANGELOG.md) under the appropriate categories with all my changes in this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Hide Clock Toggle Implementation

This PR refactors the clock visibility toggle from a "hide" perspective to a more intuitive "show" perspective.

### Changes

**index.html:**
- Changed the clock visibility toggle label from "Hide Clock" to "Show Clock"
- Updated the associated checkbox input ID from "hideClock" to "showClock"

**scripts/clock.js:**
- Refactored the entire clock visibility system to use a `showClock` state instead of `hideClock`
- `showClock` now defaults to "true" in localStorage, meaning the clock displays by default
- Updated `handleClockVisibility()` to derive visibility directly from the `showClock` localStorage value
- Added a change listener to the `showClockCheckbox` that:
  - Persists the checked state to localStorage
  - Applies corresponding CSS classes to show/hide the clock and adjust layout
  - Initializes the clock when enabled
- Enhanced the `displayClock()` function to respect the `showClock` state and properly hide both analog and digital clocks when disabled
- Simplified responsive behavior for small screens (max-width: 500px) to consistently use the `showClock` flag across all branches
- Ensures the clock options styling remains consistent with the visibility state

### Impact

The refactoring provides a more intuitive user interface where checking the toggle box shows the clock, and unchecking it hides it. The implementation is cleaner and eliminates the logic inversion that previously existed with the "hide" perspective.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->