### PR TITLE
Add section titles to Ukrainian localization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Bengali ([@prem-k-r](https://github.com/prem-k-r)), ([@itz-rj-here](https://github.com/itz-rj-here))
   - Uzbek ([S0ME2](https://github.com/S0ME2))
   - Indonesian ([@Ayyas-RF](https://github.com/Ayyas-RF))
+  - Ukrainian ([@smurf11k](https://github.com/smurf11k))
 - Corrected abbreviations for months and days of the week in Russian ([@Ayyas-RF](https://github.com/Ayyas-RF)) ([#105](https://github.com/prem-k-r/MaterialYouNewTab/pull/105))
 - Added support for Ukrainian ([@lozik4](https://github.com/lozik4)) ([#106](https://github.com/prem-k-r/MaterialYouNewTab/pull/106))
 

--- a/locales/uk.js
+++ b/locales/uk.js
@@ -11,7 +11,7 @@ const uk = {
     weatherSectionTitle: "Погода",
     appearanceSectionTitle: "Зовнішній вигляд",
     settingsSectionTitle: "Налаштування",
-    
+
     // Shortcuts
     "shortcutsText": "Ярлики",
     "enableShortcutsText": "Показати збережені ярлики",

--- a/locales/uk.js
+++ b/locales/uk.js
@@ -5,12 +5,12 @@ const uk = {
     "feedback": "Відгук",
 
     // Section titles
-    personalizationSectionTitle: "Персоналізація",
-    clockSectionTitle: "Годинник",
-    searchSectionTitle: "Пошук",
-    weatherSectionTitle: "Погода",
-    appearanceSectionTitle: "Зовнішній вигляд",
-    settingsSectionTitle: "Налаштування",
+    "personalizationSectionTitle": "Персоналізація",
+    "clockSectionTitle": "Годинник",
+    "searchSectionTitle": "Пошук",
+    "weatherSectionTitle": "Погода",
+    "appearanceSectionTitle": "Зовнішній вигляд",
+    "settingsSectionTitle": "Налаштування",
 
     // Shortcuts
     "shortcutsText": "Ярлики",

--- a/locales/uk.js
+++ b/locales/uk.js
@@ -4,6 +4,14 @@ const uk = {
     "github": "GitHub",
     "feedback": "Відгук",
 
+    // Section titles
+    personalizationSectionTitle: "Персоналізація",
+    clockSectionTitle: "Годинник",
+    searchSectionTitle: "Пошук",
+    weatherSectionTitle: "Погода",
+    appearanceSectionTitle: "Зовнішній вигляд",
+    settingsSectionTitle: "Налаштування",
+    
     // Shortcuts
     "shortcutsText": "Ярлики",
     "enableShortcutsText": "Показати збережені ярлики",


### PR DESCRIPTION
## 📌 Description

Add missing strings to Ukrainian locale file.

## ✅ Checklist

<!-- Tip: To mark a checklist item as complete, replace [ ] with [x] -->

- [x] I have read and followed the [Contributing Guidelines](https://github.com/prem-k-r/MaterialYouNewTab/blob/main/CONTRIBUTING.md).
- [x] My code follows the project's coding style and conventions.
- [x] I have tested my changes thoroughly to ensure expected behavior.
- [x] I have verified compatibility across Chrome and Firefox (additional browsers if applicable).
- [ ] I have attached relevant visual evidence (screenshots/videos) if applicable.
- [ ] I have updated the [CHANGELOG.md](https://github.com/prem-k-r/MaterialYouNewTab/blob/main/CHANGELOG.md) under the appropriate categories with all my changes in this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR adds six missing section title translations to the Ukrainian locale file (locales/uk.js). The new keys provide Ukrainian translations for:

- personalizationSectionTitle: "Персоналізація"
- clockSectionTitle: "Годинник"
- searchSectionTitle: "Пошук"
- weatherSectionTitle: "Погода"
- appearanceSectionTitle: "Зовнішній вигляд"
- settingsSectionTitle: "Налаштування"

They are placed under the existing "Section titles" comment between menu items and the Shortcuts section. The changes are purely additive (no removals or functional changes); lines changed in locales/uk.js: +8/-0.

CHANGELOG.md was also updated: the "Localized" section now includes Ukrainian ([@smurf11k]); lines changed in CHANGELOG.md: +1/-0.

Checklist highlights from the PR metadata:
- Contributing Guidelines followed: checked
- Code style/conventions: checked
- Tested for expected behavior: checked (verified on Chrome and Firefox)
- Attached visual evidence: unchecked
- Updated CHANGELOG.md: checked
<!-- end of auto-generated comment: release notes by coderabbit.ai -->