### PR TITLE
Add SVG support for shortcuts #69

### DIFF
--- a/scripts/shortcuts.js
+++ b/scripts/shortcuts.js
@@ -144,7 +144,7 @@ document.addEventListener("DOMContentLoaded", function () {
         for (let i = 0; i < amount; i++) {
             const name = localStorage.getItem(`shortcutName${i}`) || (presets[i] ? presets[i].name : PLACEHOLDER.name);
             const url = localStorage.getItem(`shortcutURL${i}`) || (presets[i] ? presets[i].url : PLACEHOLDER.url);
-            const svg = localStorage.getItem(`shortcutSVG${i}`) || (presets[i] ? presets[i].svg : PLACEHOLDER.svg);
+            const svg = localStorage.getItem(`shortcutSVG${i}`) ?? (presets[i]?.svg ?? "");
 
             shortcutsCache.push({ name, url, svg });
 
@@ -272,6 +272,8 @@ document.addEventListener("DOMContentLoaded", function () {
     
         const allowedAttrs = new Set([
             "d", "fill", "stroke", "stroke-width",
+            "fill-rule", "clip-rule",
+            "stroke-linecap", "stroke-linejoin",
             "viewBox", "cx", "cy", "r",
             "x", "y", "width", "height",
             "points", "transform", "xmlns",
@@ -279,25 +281,26 @@ document.addEventListener("DOMContentLoaded", function () {
         ]);
     
         function clean(node) {
-            // Remove disallowed elements
-            if (!allowedTags.has(node.nodeName)) {
+            // Remove disallowed elements (case-insensitive comparison)
+            if (!allowedTags.has(node.nodeName.toLowerCase())) {
                 node.remove();
                 return;
             }
     
-            // Remove dangerous attributes
+            // Remove dangerous attributes (case-insensitive comparison, remove by original name)
             [...node.attributes].forEach(attr => {
                 const name = attr.name;
+                const nameLower = name.toLowerCase();
                 const value = attr.value;
             
-                const isEvent = name.startsWith("on");
-                const isHref = name === "href" || name === "xlink:href";
+                const isEvent = nameLower.startsWith("on");
+                const isHref = nameLower === "href" || nameLower === "xlink:href";
                 const isDangerousUrl = /javascript:/i.test(value) || /url\s*\(/i.test(value);
             
-                const isBadStyle = name === "style" && !/^\s*transform\s*:/i.test(value);
+                const isBadStyle = nameLower === "style" && !/^\s*transform\s*:/i.test(value);
             
                 if (
-                    !allowedAttrs.has(name) ||
+                    !allowedAttrs.has(nameLower) ||
                     isEvent ||
                     isHref ||
                     isDangerousUrl ||
@@ -313,7 +316,7 @@ document.addEventListener("DOMContentLoaded", function () {
     
         const svg = doc.documentElement;
     
-        if (svg.nodeName === "parsererror") {
+        if (svg.nodeName === "parsererror" || svg.nodeName.toLowerCase() !== "svg") {
             return null;
         }
     
@@ -376,7 +379,8 @@ document.addEventListener("DOMContentLoaded", function () {
         });
 
         inputs[0].addEventListener("keydown", e => e.key === "Enter" && inputs[1].focus());
-        inputs[1].addEventListener("keydown", e => e.key === "Enter" && e.target.blur());
+        inputs[1].addEventListener("keydown", e => e.key === "Enter" && inputs[2].focus());
+        inputs[2].addEventListener("keydown", e => e.key === "Enter" && e.target.blur());
     }
 
     // Drag and drop functionality for reordering shortcuts

--- a/scripts/shortcuts.js
+++ b/scripts/shortcuts.js
@@ -182,7 +182,7 @@ document.addEventListener("DOMContentLoaded", function () {
             <div>
                 <input class="shortcutName" placeholder="${PLACEHOLDER.inputName}" value="${escapeHtml(name)}">
                 <input class="URL" placeholder="${PLACEHOLDER.inputUrl}" value="${escapeHtml(url)}">
-                <input class="SVG" placeholder="${PLACEHOLDER.inputSvg}">
+                <input class="SVG" placeholder="${PLACEHOLDER.inputSvg}" value="${escapeHtml(svg)}">            
             </div>
             <div class="delete">
                 <button class="${deleteInactive ? 'inactive' : ''}">
@@ -274,7 +274,8 @@ document.addEventListener("DOMContentLoaded", function () {
             "d", "fill", "stroke", "stroke-width",
             "viewBox", "cx", "cy", "r",
             "x", "y", "width", "height",
-            "points", "transform", "xmlns"
+            "points", "transform", "xmlns",
+            "class", "style"
         ]);
     
         function clean(node) {
@@ -288,16 +289,19 @@ document.addEventListener("DOMContentLoaded", function () {
             [...node.attributes].forEach(attr => {
                 const name = attr.name;
                 const value = attr.value;
-    
+            
                 const isEvent = name.startsWith("on");
                 const isHref = name === "href" || name === "xlink:href";
-                const isDangerousUrl = value.includes("javascript:");
-    
+                const isDangerousUrl = /javascript:/i.test(value) || /url\s*\(/i.test(value);
+            
+                const isBadStyle = name === "style" && !/^\s*transform\s*:/i.test(value);
+            
                 if (
                     !allowedAttrs.has(name) ||
                     isEvent ||
                     isHref ||
-                    isDangerousUrl
+                    isDangerousUrl ||
+                    isBadStyle
                 ) {
                     node.removeAttribute(name);
                 }

--- a/scripts/shortcuts.js
+++ b/scripts/shortcuts.js
@@ -664,7 +664,7 @@ document.addEventListener("DOMContentLoaded", function () {
 
         return newOrder.some((item, index) => {
             const cached = shortcutsCache[index];
-            return item.name !== cached.name || item.url !== cached.url;
+            return item.name !== cached.name || item.url !== cached.url || item.svg !== cached.svg;
         });
     }
 

--- a/scripts/shortcuts.js
+++ b/scripts/shortcuts.js
@@ -182,7 +182,7 @@ document.addEventListener("DOMContentLoaded", function () {
             <div>
                 <input class="shortcutName" placeholder="${PLACEHOLDER.inputName}" value="${escapeHtml(name)}">
                 <input class="URL" placeholder="${PLACEHOLDER.inputUrl}" value="${escapeHtml(url)}">
-                <input class="SVG" placeholder="${PLACEHOLDER.inputSvg}" value="${escapeHtml(svg)}">
+                <input class="SVG" placeholder="${PLACEHOLDER.inputSvg}">
             </div>
             <div class="delete">
                 <button class="${deleteInactive ? 'inactive' : ''}">

--- a/scripts/shortcuts.js
+++ b/scripts/shortcuts.js
@@ -12,7 +12,7 @@ document.addEventListener("DOMContentLoaded", function () {
         url: "https://github.com/prem-k-r/MaterialYouNewTab",
         inputName: "Shortcut Name",
         inputUrl: "Shortcut URL",
-        svg: "Shortcut SVG"
+        inputSvg: "Shortcut SVG"
     };
 
     // DOM Elements
@@ -364,6 +364,7 @@ document.addEventListener("DOMContentLoaded", function () {
                 renderShortcut(
                     entry.querySelector(".shortcutName").value,
                     entry.querySelector(".URL").value,
+                    entry.querySelector(".SVG").value,
                     entry._index
                 );
             });
@@ -716,11 +717,11 @@ document.addEventListener("DOMContentLoaded", function () {
             dom.newShortcutButton.classList.add("inactive");
         }
 
-        const entry = createShortcutEntry(PLACEHOLDER.name, PLACEHOLDER.url, false, currentAmount);
+        const entry = createShortcutEntry(PLACEHOLDER.name, PLACEHOLDER.url, "" ,false, currentAmount);
         dom.shortcutSettingsContainer.appendChild(entry);
 
         saveShortcut(entry);
-        renderShortcut(PLACEHOLDER.name, PLACEHOLDER.url, currentAmount);
+        renderShortcut(PLACEHOLDER.name, PLACEHOLDER.url, "" ,currentAmount);
     }
 
     // Deletes a shortcut

--- a/scripts/shortcuts.js
+++ b/scripts/shortcuts.js
@@ -274,7 +274,7 @@ document.addEventListener("DOMContentLoaded", function () {
             "d", "fill", "stroke", "stroke-width",
             "fill-rule", "clip-rule",
             "stroke-linecap", "stroke-linejoin",
-            "viewBox", "cx", "cy", "r",
+            "viewbox", "cx", "cy", "r",
             "x", "y", "width", "height",
             "points", "transform", "xmlns",
             "class", "style"

--- a/scripts/shortcuts.js
+++ b/scripts/shortcuts.js
@@ -11,7 +11,8 @@ document.addEventListener("DOMContentLoaded", function () {
         name: "New shortcut",
         url: "https://github.com/prem-k-r/MaterialYouNewTab",
         inputName: "Shortcut Name",
-        inputUrl: "Shortcut URL"
+        inputUrl: "Shortcut URL",
+        svg: "Shortcut SVG"
     };
 
     // DOM Elements
@@ -143,12 +144,13 @@ document.addEventListener("DOMContentLoaded", function () {
         for (let i = 0; i < amount; i++) {
             const name = localStorage.getItem(`shortcutName${i}`) || (presets[i] ? presets[i].name : PLACEHOLDER.name);
             const url = localStorage.getItem(`shortcutURL${i}`) || (presets[i] ? presets[i].url : PLACEHOLDER.url);
+            const svg = localStorage.getItem(`shortcutSVG${i}`) || (presets[i] ? presets[i].svg : PLACEHOLDER.svg);
 
-            shortcutsCache.push({ name, url });
+            shortcutsCache.push({ name, url, svg });
 
-            const entry = createShortcutEntry(name, url, deleteInactive, i);
+            const entry = createShortcutEntry(name, url, svg, deleteInactive, i);
             dom.shortcutSettingsContainer.appendChild(entry);
-            renderShortcut(name, url, i);
+            renderShortcut(name, url, svg, i);
         }
 
         // Disable new shortcut button if max reached
@@ -160,7 +162,7 @@ document.addEventListener("DOMContentLoaded", function () {
     }
 
     // Creates a shortcut entry element for the settings panel
-    function createShortcutEntry(name, url, deleteInactive, index) {
+    function createShortcutEntry(name, url, svg, deleteInactive, index) {
         const entry = document.createElement("div");
         entry.className = "shortcutSettingsEntry";
         entry.draggable = true;
@@ -180,6 +182,7 @@ document.addEventListener("DOMContentLoaded", function () {
             <div>
                 <input class="shortcutName" placeholder="${PLACEHOLDER.inputName}" value="${escapeHtml(name)}">
                 <input class="URL" placeholder="${PLACEHOLDER.inputUrl}" value="${escapeHtml(url)}">
+                <input class="SVG" placeholder="${PLACEHOLDER.inputSvg}" value="${escapeHtml(svg)}">
             </div>
             <div class="delete">
                 <button class="${deleteInactive ? 'inactive' : ''}">
@@ -199,37 +202,37 @@ document.addEventListener("DOMContentLoaded", function () {
         return entry;
     }
 
-    function createShortcutElement(name, url, index) {
+    function createShortcutElement(name, url, svg, index) {
         const normalizedUrl = normalizeUrl(url);
-
+    
         const shortcut = document.createElement("div");
         shortcut.className = "shortcuts";
         shortcut._index = index;
-
+    
         const link = document.createElement("a");
         link.href = normalizedUrl;
-
+    
         const logoContainer = document.createElement("div");
         logoContainer.className = "shortcutLogoContainer";
-
-        const logo = getLogoHtml(normalizedUrl);
+    
+        const logo = getLogoHtml(normalizedUrl, svg);
         if (logo) logoContainer.appendChild(logo);
-
+    
         const span = document.createElement("span");
         span.className = "shortcut-name";
         span.textContent = name;
-
+    
         link.appendChild(logoContainer);
         link.appendChild(span);
         shortcut.appendChild(link);
-
+    
         return shortcut;
     }
 
     // Renders a shortcut in the main view
-    function renderShortcut(name, url, index) {
-        const shortcut = createShortcutElement(name, url, index);
-
+    function renderShortcut(name, url, svg, index) {
+        const shortcut = createShortcutElement(name, url, svg, index);
+    
         if (index < dom.shortcutsContainer.children.length) {
             dom.shortcutsContainer.replaceChild(shortcut, dom.shortcutsContainer.children[index]);
         } else {
@@ -256,10 +259,74 @@ document.addEventListener("DOMContentLoaded", function () {
         );
     }
 
+    function sanitizeSVG(svgString) {
+        if (!svgString || typeof svgString !== "string") return null;
+    
+        const parser = new DOMParser();
+        const doc = parser.parseFromString(svgString, "image/svg+xml");
+    
+        const allowedTags = new Set([
+            "svg", "g", "path", "circle", "rect", "line",
+            "polyline", "polygon", "ellipse"
+        ]);
+    
+        const allowedAttrs = new Set([
+            "d", "fill", "stroke", "stroke-width",
+            "viewBox", "cx", "cy", "r",
+            "x", "y", "width", "height",
+            "points", "transform", "xmlns"
+        ]);
+    
+        function clean(node) {
+            // Remove disallowed elements
+            if (!allowedTags.has(node.nodeName)) {
+                node.remove();
+                return;
+            }
+    
+            // Remove dangerous attributes
+            [...node.attributes].forEach(attr => {
+                const name = attr.name;
+                const value = attr.value;
+    
+                const isEvent = name.startsWith("on");
+                const isHref = name === "href" || name === "xlink:href";
+                const isDangerousUrl = value.includes("javascript:");
+    
+                if (
+                    !allowedAttrs.has(name) ||
+                    isEvent ||
+                    isHref ||
+                    isDangerousUrl
+                ) {
+                    node.removeAttribute(name);
+                }
+            });
+    
+            // Recursively clean children
+            [...node.children].forEach(child => clean(child));
+        }
+    
+        const svg = doc.documentElement;
+    
+        if (svg.nodeName === "parsererror") {
+            return null;
+        }
+    
+        clean(svg);
+    
+        return svg;
+    }
+    
     // Gets the appropriate logo HTML for a given URL
-    function getLogoHtml(url) {
+    function getLogoHtml(url, svg) {
         const hostname = new URL(normalizeUrl(url)).hostname.replace(/^www\./, "");
 
+        if (svg) {
+            const svgEl = sanitizeSVG(svg);
+            if (svgEl) return svgEl.cloneNode(true);
+        }
+        
         // GitHub shortcut
         if (hostname === "github.com") {
             const img = document.createElement("img");
@@ -564,7 +631,8 @@ document.addEventListener("DOMContentLoaded", function () {
         const entries = dom.shortcutSettingsContainer.querySelectorAll(".shortcutSettingsEntry");
         const newOrder = Array.from(entries).map(entry => ({
             name: entry.querySelector(".shortcutName").value,
-            url: entry.querySelector(".URL").value
+            url: entry.querySelector(".URL").value,
+            svg: entry.querySelector(".SVG").value
         }));
 
         // Only save if order has changed
@@ -573,6 +641,7 @@ document.addEventListener("DOMContentLoaded", function () {
             newOrder.forEach((item, index) => {
                 localStorage.setItem(`shortcutName${index}`, item.name);
                 localStorage.setItem(`shortcutURL${index}`, item.url);
+                localStorage.setItem(`shortcutSVG${index}`, item.svg);
             });
 
             shortcutsCache = newOrder;
@@ -593,11 +662,13 @@ document.addEventListener("DOMContentLoaded", function () {
     // Renders all shortcuts in the main view
     function renderAllShortcuts(order) {
         const fragment = document.createDocumentFragment();
-
+    
         order.forEach((item, index) => {
-            fragment.appendChild(createShortcutElement(item.name, item.url, index));
+            fragment.appendChild(
+                createShortcutElement(item.name, item.url, item.svg, index)
+            );
         });
-
+    
         dom.shortcutsContainer.innerHTML = "";
         dom.shortcutsContainer.appendChild(fragment);
     }
@@ -717,5 +788,6 @@ document.addEventListener("DOMContentLoaded", function () {
     function saveShortcut(entry) {
         localStorage.setItem(`shortcutName${entry._index}`, entry.querySelector(".shortcutName").value);
         localStorage.setItem(`shortcutURL${entry._index}`, entry.querySelector(".URL").value);
+        localStorage.setItem(`shortcutSVG${entry._index}`, entry.querySelector(".SVG").value);
     }
 });

--- a/scripts/shortcuts.js
+++ b/scripts/shortcuts.js
@@ -746,6 +746,7 @@ document.addEventListener("DOMContentLoaded", function () {
         }
         localStorage.removeItem(`shortcutName${currentAmount - 1}`);
         localStorage.removeItem(`shortcutURL${currentAmount - 1}`);
+        localStorage.removeItem(`shortcutSVG${currentAmount - 1}`);
 
         if (currentAmount - 1 === 1) {
             document.querySelectorAll(".delete button").forEach(b => {
@@ -773,6 +774,7 @@ document.addEventListener("DOMContentLoaded", function () {
         for (let i = 0; i < (localStorage.getItem("shortcutAmount") || 0); i++) {
             localStorage.removeItem(`shortcutName${i}`);
             localStorage.removeItem(`shortcutURL${i}`);
+            localStorage.removeItem(`shortcutSVG${i}`);
         }
         localStorage.removeItem("shortcutAmount");
 

--- a/scripts/shortcuts.js
+++ b/scripts/shortcuts.js
@@ -295,7 +295,8 @@ document.addEventListener("DOMContentLoaded", function () {
             
                 const isEvent = nameLower.startsWith("on");
                 const isHref = nameLower === "href" || nameLower === "xlink:href";
-                const isDangerousUrl = /javascript:/i.test(value) || /url\s*\(/i.test(value);
+                // Treat javascript: as dangerous and block url(...) except for internal SVG fragments url(#...)
+                const isDangerousUrl = /javascript:/i.test(value) || /url\s*\(\s*(?!['"]?#)/i.test(value);
             
                 const isBadStyle = nameLower === "style" && !/^\s*transform\s*:/i.test(value);
             


### PR DESCRIPTION
## 📌 Description

Add SVG support for shortcuts

## 🎨 Visual Changes (Screenshots / Videos)

https://github.com/user-attachments/assets/f0b6e48b-da48-41f3-83ba-238a6b485263

## 🔗 Related Issues

- Closes #69 
- Related to #69

## ✅ Checklist

- [X] I have read and followed the [Contributing Guidelines](https://github.com/prem-k-r/MaterialYouNewTab/blob/main/CONTRIBUTING.md).
- [X] My code follows the project's coding style and conventions.
- [X] I have tested my changes thoroughly to ensure expected behavior.
- [X] I have verified compatibility across Chrome and Firefox (additional browsers if applicable).
- [X] I have attached relevant visual evidence (screenshots/videos) if applicable.
- [ ] I have updated the [CHANGELOG.md](https://github.com/prem-k-r/MaterialYouNewTab/blob/main/CHANGELOG.md) under the appropriate categories with all my changes in this PR.

> [!WARNING]
> Still Needs Some Review: DO NOT MERGE!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR adds SVG support for shortcuts, letting users provide custom SVG markup per shortcut (closes issue #69 — custom website icon functionality). It extends the shortcuts UI, storage, rendering, reordering, and sanitization flows so custom SVGs can replace or supplement fetched favicons.

Changes

- scripts/shortcuts.js (+110/-26):
  - Per-shortcut SVG storage: introduces persistence under localStorage keys shortcutSVG{index}; loading falls back to presets[i]?.svg when present.
  - UI: adds a per-shortcut SVG input (PLACEHOLDER.inputSvg / .SVG) in the shortcut settings; Enter on the URL input now focuses the SVG input, and Enter on the SVG input blurs.
  - In-memory model & placeholders: shortcutsCache entries and newly created placeholders now include an svg field.
  - Rendering: createShortcutElement, renderShortcut, and getLogoHtml now accept an svg parameter and prefer a provided sanitized SVG clone over fetched/preset icons; existing GitHub/preset/favicon fallback logic remains.
  - Sanitization: adds sanitizeSVG(svgString) which parses SVG via DOMParser, permits only a restricted set of SVG elements (svg, g, path, circle, rect, line, polyline, polygon, ellipse, etc.), strips disallowed tags and attributes, removes event handlers and href/xlink:href, and rejects/cleans values containing javascript: or url( patterns and unsafe style entries; returns a cleaned SVG string or null.
  - Persistence updates: saves SVG on individual blur saves, during reorder (drag) saves, on deletion, and on full reset; deletion/reset remove corresponding shortcutSVG entries.
  - Ordering logic: hasOrderChanged / saveShortcutOrder logic updated to include svg so reordering persists SVG fields correctly.

Other notes

- No exported/public API changes (all changes are internal).
- Visual evidence attached in the PR; verified on Chrome and Firefox.
- Checklist: contributing guidelines followed; code style adhered to; tests/visual verification done; CHANGELOG.md update still pending.
- PR flagged with a warning: "Still Needs Some Review: DO NOT MERGE!" Estimated review effort: high.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->