### PR TITLE
style: apply color inversion filters to shortcuts and tIcon elements

### DIFF
--- a/style.css
+++ b/style.css
@@ -235,8 +235,13 @@ html:has(
 
 	& #darkTheme,
 	& .favicon,
-	& .shortcuts,
+	& .shortcuts a,
 	& .tIcon {
+		filter: invert(1) hue-rotate(180deg);
+		-webkit-filter: invert(1) hue-rotate(180deg);
+	}
+
+	& .shortcut-name {
 		filter: invert(1) hue-rotate(180deg);
 		-webkit-filter: invert(1) hue-rotate(180deg);
 	}
@@ -275,8 +280,13 @@ body[data-bg="wallpaper"][sysTheme="systemDark"]:has(
 
 	& #darkTheme,
 	& .favicon,
-	& .shortcuts,
+	& .shortcuts a,
 	& .tIcon {
+		filter: invert(1) hue-rotate(180deg);
+		-webkit-filter: invert(1) hue-rotate(180deg);
+	}
+
+	& .shortcut-name {
 		filter: invert(1) hue-rotate(180deg);
 		-webkit-filter: invert(1) hue-rotate(180deg);
 	}

--- a/style.css
+++ b/style.css
@@ -234,7 +234,9 @@ html:has(
 	-webkit-filter: invert(1) hue-rotate(180deg);
 
 	& #darkTheme,
-	& .favicon {
+	& .favicon,
+	& .shortcuts,
+	& .tIcon {
 		filter: invert(1) hue-rotate(180deg);
 		-webkit-filter: invert(1) hue-rotate(180deg);
 	}
@@ -272,7 +274,9 @@ body[data-bg="wallpaper"][sysTheme="systemDark"]:has(
 	-webkit-filter: invert(1) hue-rotate(180deg);
 
 	& #darkTheme,
-	& .favicon {
+	& .favicon,
+	& .shortcuts,
+	& .tIcon {
 		filter: invert(1) hue-rotate(180deg);
 		-webkit-filter: invert(1) hue-rotate(180deg);
 	}


### PR DESCRIPTION
## 📌 Description

According to issue #157 the icon color of shortcuts needs to be changed to remain constant irrelevant to theme, Along with this I **also made changes to the AI Icons** since they were also similar (if this was not to be done please comment on this PR)

## 🎨 Visual Changes (Screenshots / Videos)

<img width="1919" height="902" alt="image" src="https://github.com/user-attachments/assets/7553ce34-2cb7-4c22-9059-a62d2ea7940e" />
<img width="1919" height="907" alt="image" src="https://github.com/user-attachments/assets/4abdee8e-d11e-492e-be4b-af36163f792b" />



## 🔗 Related Issues

- Closes #157  

## ✅ Checklist

- [ X] I have read and followed the [Contributing Guidelines](https://github.com/prem-k-r/MaterialYouNewTab/blob/main/CONTRIBUTING.md).
- [X ] My code follows the project's coding style and conventions.
- [X ] I have tested my changes thoroughly to ensure expected behavior.
- [X ] I have verified compatibility across Chrome and Firefox (additional browsers if applicable).
- [X ] I have attached relevant visual evidence (screenshots/videos) if applicable.
- [ ] I have updated the [CHANGELOG.md](https://github.com/prem-k-r/MaterialYouNewTab/blob/main/CHANGELOG.md) under the appropriate categories with all my changes in this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Changes

This PR applies CSS color inversion filters to shortcut icons and tIcon elements to prevent them from changing color when switching between light and dark themes.

### Modified Files

**style.css**
- Updated dark-mode inversion rules in both the general dark-mode selector and the wallpaper system-dark variant
- Extended `filter: invert(1) hue-rotate(180deg)` (and `-webkit-filter`) to `.shortcuts a` and `.tIcon` in addition to `#darkTheme` and `.favicon`
- The `.shortcut-name` filter rule remains separate
- Lines changed: +16/-2

## Related Issue

Fixes #157 - Shortcut icons were changing color when switching between light and dark themes

## Author Notes

The author also applied the same color inversion to AI icons and requests feedback whether that was intended.

## Review Checklist Status

- ✅ Contribution guidelines followed
- ✅ Styling/conventions observed
- ✅ Tests run
- ✅ Cross-browser verification (Chrome and Firefox)
- ✅ Visual evidence provided
- ⚠️ CHANGELOG.md not updated
<!-- end of auto-generated comment: release notes by coderabbit.ai -->