### PR TITLE
Fix shortcut icon color in dark mode (#157)

### DIFF
--- a/style.css
+++ b/style.css
@@ -5414,3 +5414,7 @@ body[data-bg="wallpaper"] .dropdown-content {
 	color: var(--darkColor-dark);
 }
 /* ------------ End of Toast---------- */
+/* fix dark mode shortcut icon color */
+[data-theme="dark"] .shortcut {
+    filter: invert(1) contrast(1.2);
+}


### PR DESCRIPTION
## 📌 Description

Fixed issue #157.
Shortcut icons were displaying incorrectly when switching to dark mode.
Added a CSS override to ensure icons remain properly visible and contrasted in dark theme.

## 🎨 Visual Changes (Screenshots / Videos)

Not applicable. This change only updates CSS behavior for dark mode.

## 🔗 Related Issues

- Closes #157

## ✅ Checklist

- [x] I have read and followed the Contributing Guidelines.
- [x] My code follows the project's coding style and conventions.
- [x] I have tested my changes to ensure expected behavior.
- [ ] I have verified compatibility across Chrome and Firefox.
- [ ] I have attached relevant visual evidence if applicable.
- [ ] I have updated the CHANGELOG.md.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR fixes shortcut icon visibility in dark mode by adding a CSS filter to adjust their appearance when the dark theme is active.

## Changes

**style.css**
- Added dark-theme-specific CSS rule targeting elements with `[data-theme="dark"]` attribute and `.shortcut` class
- Applied `filter: invert(1) contrast(1.2)` to invert colors and increase contrast by 20% for proper icon visibility in dark mode

## Impact

- Ensures shortcut icons remain visible and properly contrasted when switching from light to dark theme
- Addresses the visual regression reported in issue #157 where shortcut icons lost correct appearance in dark mode
- CSS-only change with no impact to exported or public code entities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->