### PR TITLE
Make images non-draggable in index.html

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Corrected abbreviations for months and days of the week in Russian ([@Ayyas-RF](https://github.com/Ayyas-RF)) ([#105](https://github.com/prem-k-r/MaterialYouNewTab/pull/105))
 - Added support for Ukrainian ([@lozik4](https://github.com/lozik4)) ([#106](https://github.com/prem-k-r/MaterialYouNewTab/pull/106))
 
+### Other
+
+- Disabled dragging for weather and location icons ([@anndiy](https://github.com/anndiy)) ([#183](https://github.com/prem-k-r/MaterialYouNewTab/pull/183))
+
 ## [v3.3](https://github.com/prem-k-r/MaterialYouNewTab/compare/v3.2...v3.3) - Nov 23, 2025
 
 ### Added

--- a/index.html
+++ b/index.html
@@ -645,7 +645,7 @@
                             </div>
                             <div class="tiles location">
                                 <div class="icon">
-                                    <img class="location-icon" src="./svgs/location.svg" alt="">
+                                    <img class="location-icon"  draggable="false" src="./svgs/location.svg" alt="">
                                 </div>
                                 <span class="location_spn" id="location"></span>
                             </div>
@@ -663,7 +663,7 @@
                     </svg>
                     <div class="wInfo">
                         <div id="temp">?</div>
-                        <img alt="" id="wIcon" src="./svgs/defaultWeather.svg">
+                        <img alt="" id="wIcon" draggable="false" src="./svgs/defaultWeather.svg">
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
This PR disabled the sun icon (id="wIcon") and location icon (class="location-icon") to prevent accidental dragging.

## 📌 Description
Noticed the sun icon is draggable, so added  `draggable="false"` to the img as well as the other image I found. 

<!-- Please provide a clear and concise description of the changes introduced in this PR and their purpose. -->

## 🎨 Visual Changes (Screenshots / Videos)
Before: 
<img width="514" height="502" alt="image" src="https://github.com/user-attachments/assets/25f67777-e226-4a66-830f-614c5b68840b" />

## ✅ Checklist

<!-- Tip: To mark a checklist item as complete, replace [ ] with [x] -->

- [x] I have read and followed the [Contributing Guidelines](https://github.com/prem-k-r/MaterialYouNewTab/blob/main/CONTRIBUTING.md).
- [x] My code follows the project's coding style and conventions.
- [x] I have tested my changes thoroughly to ensure expected behavior.
- [x] I have verified compatibility across Chrome and Firefox (additional browsers if applicable).
- [x] I have attached relevant visual evidence (screenshots/videos) if applicable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR prevents accidental dragging of weather-related UI elements by adding the `draggable="false"` attribute to two image elements in `index.html`:

1. **Location icon** - Added `draggable="false"` to the image with `class="location-icon"`.
2. **Weather icon** - Added `draggable="false"` to the image with `id="wIcon"`.

Additionally, `index.html` was normalized to end with a newline. The changelog (`CHANGELOG.md`) was updated under the Unreleased → Other section to note that dragging was disabled for the weather and location icons.

**Changes:** small edits to `index.html` and an addition to `CHANGELOG.md`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->