### PR TITLE
feat: add custom icons for shortcuts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,13 +18,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added support for touch-swipe and mouse-wheel gestures on the search engine icon to switch search engines when they are hidden ([@prem-k-r](https://github.com/prem-k-r)) ([#145](https://github.com/prem-k-r/MaterialYouNewTab/pull/145))
+- Added custom icon load for shortcuts ([@smurf11k](https://github.com/smurf11k)) [#187](https://github.com/prem-k-r/MaterialYouNewTab/pull/187/)
 
 ### Improved
 
 - Introduced collapsible sections in the settings menu for improved organization and easier navigation ([@prem-k-r](https://github.com/prem-k-r)) ([#109](https://github.com/prem-k-r/MaterialYouNewTab/pull/109))
 - Redesigned the theme selector from dropdown to buttons for easier switching between Light, Dark, and System modes ([@prem-k-r](https://github.com/prem-k-r)) ([#112](https://github.com/prem-k-r/MaterialYouNewTab/pull/112))
 - Added expanding animations to todo and Google apps panels and some other minor UI changes ([@prem-k-r](https://github.com/prem-k-r)) ([#118](https://github.com/prem-k-r/MaterialYouNewTab/pull/118))
-- Added custom icon load for shortcuts ([@smurf11k](https://github.com/smurf11k))
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Introduced collapsible sections in the settings menu for improved organization and easier navigation ([@prem-k-r](https://github.com/prem-k-r)) ([#109](https://github.com/prem-k-r/MaterialYouNewTab/pull/109))
 - Redesigned the theme selector from dropdown to buttons for easier switching between Light, Dark, and System modes ([@prem-k-r](https://github.com/prem-k-r)) ([#112](https://github.com/prem-k-r/MaterialYouNewTab/pull/112))
 - Added expanding animations to todo and Google apps panels and some other minor UI changes ([@prem-k-r](https://github.com/prem-k-r)) ([#118](https://github.com/prem-k-r/MaterialYouNewTab/pull/118))
+- Added custom icon load for shortcuts ([@smurf11k](https://github.com/smurf11k))
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added support for touch-swipe and mouse-wheel gestures on the search engine icon to switch search engines when they are hidden ([@prem-k-r](https://github.com/prem-k-r)) ([#145](https://github.com/prem-k-r/MaterialYouNewTab/pull/145))
-- Added custom icon load for shortcuts ([@smurf11k](https://github.com/smurf11k)) [#187](https://github.com/prem-k-r/MaterialYouNewTab/pull/187/)
+- Added support for custom shortcut icons via upload or URL ([@smurf11k](https://github.com/smurf11k)), ([@prem-k-r](https://github.com/prem-k-r)) [#187](https://github.com/prem-k-r/MaterialYouNewTab/pull/187/)
 
 ### Improved
 
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Redesigned the theme selector from dropdown to buttons for easier switching between Light, Dark, and System modes ([@prem-k-r](https://github.com/prem-k-r)) ([#112](https://github.com/prem-k-r/MaterialYouNewTab/pull/112))
 - Added expanding animations to todo and Google apps panels and some other minor UI changes ([@prem-k-r](https://github.com/prem-k-r)) ([#118](https://github.com/prem-k-r/MaterialYouNewTab/pull/118))
 - Prevented weather condition and shortcut icons from being color-inverted in dark mode ([@prem-k-r](https://github.com/prem-k-r)) ([#191](https://github.com/prem-k-r/MaterialYouNewTab/pull/191))
+- Improved fallback behavior of shortcut icons to first-letter icons when custom icons fail to load or when offline ([@prem-k-r](https://github.com/prem-k-r))
 
 ### Fixed
 

--- a/locales/en.js
+++ b/locales/en.js
@@ -210,5 +210,5 @@ const en = {
     "UnsupportedBrowser": "Bookmarks are not supported in your browser.",
     "resetShortcutsPrompt": "All saved shortcuts will be deleted and reset to default. Do you want to continue?",
     "iconFileTooLargeMessage": "Selected file is too large: {size}. Please use a file smaller than 100 KB.",
-    "iconStorageQuotaMessage": "Icon couldn’t be saved: storage limit reached. Please use a smaller image."
+    "iconStorageQuotaMessage": "Icon couldn’t be saved because the storage limit has been reached. Please use a smaller image."
 };

--- a/locales/en.js
+++ b/locales/en.js
@@ -210,5 +210,5 @@ const en = {
     "UnsupportedBrowser": "Bookmarks are not supported in your browser.",
     "resetShortcutsPrompt": "All saved shortcuts will be deleted and reset to default. Do you want to continue?",
     "iconFileTooLargeMessage": "Selected file is too large: {size}. Please use a file smaller than 100 KB.",
-    "iconStorageQuotaMessage": "Icon couldn’t be saved because the storage limit has been reached. Please use a smaller image."
+    "iconStorageQuotaMessage": "Icon couldn’t be saved because the storage limit has been reached. Remove some custom icons or use a smaller image."
 };

--- a/locales/en.js
+++ b/locales/en.js
@@ -208,5 +208,7 @@ const en = {
     "invalidBackup": "Invalid backup file selected.",
     "deleteBookmark": "Are you sure you want to delete the bookmark \"{title}\"?",  // Do not translate {title}
     "UnsupportedBrowser": "Bookmarks are not supported in your browser.",
-    "resetShortcutsPrompt": "All saved shortcuts will be deleted and reset to default. Do you want to continue?"
+    "resetShortcutsPrompt": "All saved shortcuts will be deleted and reset to default. Do you want to continue?",
+    "iconFileTooLargeMessage": "Selected file is too large: {size}. Please use a file smaller than 100 KB.",
+    "iconStorageQuotaMessage": "Icon couldn’t be saved: storage limit reached. Please use a smaller image."
 };

--- a/manifest(firefox).json
+++ b/manifest(firefox).json
@@ -1,7 +1,7 @@
 {
 	"manifest_version": 2,
 	"name": "MYNT: Material You New Tab",
-	"version": "3.3.0501",
+	"version": "3.3.501",
 	"description": "A Simple New Tab (browser's home page) inspired by Google's 'Material You' design.",
 	"permissions": [
 		"search",

--- a/manifest(firefox).json
+++ b/manifest(firefox).json
@@ -1,7 +1,7 @@
 {
 	"manifest_version": 2,
 	"name": "MYNT: Material You New Tab",
-	"version": "3.3.0427",
+	"version": "3.3.0501",
 	"description": "A Simple New Tab (browser's home page) inspired by Google's 'Material You' design.",
 	"permissions": [
 		"search",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"manifest_version": 3,
 	"name": "MYNT: Material You New Tab",
-	"version": "3.3.0501",
+	"version": "3.3.501",
 	"description": "A Simple New Tab (browser's home page) inspired by Google's 'Material You' design.",
 	"permissions": ["search"],
 	"optional_permissions": ["bookmarks", "favicon"],

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"manifest_version": 3,
 	"name": "MYNT: Material You New Tab",
-	"version": "3.3.0427",
+	"version": "3.3.0501",
 	"description": "A Simple New Tab (browser's home page) inspired by Google's 'Material You' design.",
 	"permissions": ["search"],
 	"optional_permissions": ["bookmarks", "favicon"],

--- a/scripts/languages.js
+++ b/scripts/languages.js
@@ -237,7 +237,9 @@ function applyLanguage(lang) {
         "searchSectionTitle",
         "weatherSectionTitle",
         "appearanceSectionTitle",
-        "settingsSectionTitle"
+        "settingsSectionTitle",
+        "iconFileTooLargeMessage",
+        "iconStorageQuotaMessage"
     ];
 
     // Specific mapping for placeholders

--- a/scripts/shortcuts.js
+++ b/scripts/shortcuts.js
@@ -230,15 +230,35 @@ document.addEventListener("DOMContentLoaded", function () {
             const reader = new FileReader();
             reader.onload = () => {
                 iconInput.value = reader.result;
-                saveShortcut(entry);
-                
-                // Render with the current icon value (may be empty if quota was exceeded)
-                renderShortcut(
-                    entry.querySelector(".shortcutName").value,
-                    entry.querySelector(".URL").value,
-                    iconInput.value,
-                    entry._index
-                );
+                try {
+                    saveShortcut(entry);
+                    
+                    // Render with the current icon value (may be empty if quota was exceeded)
+                    renderShortcut(
+                        entry.querySelector(".shortcutName").value,
+                        entry.querySelector(".URL").value,
+                        iconInput.value,
+                        entry._index
+                    );
+                } catch (err) {
+                    const msg = "Unable to save the icon — storage is full. Try removing other custom icons or using a smaller image.";
+                    if (typeof alertPrompt === "function") {
+                        alertPrompt(msg);
+                    } else {
+                        alert(msg);
+                    }
+                    iconInput.value = "";
+                } finally {
+                    fileInput.value = "";
+                }
+            };
+            reader.onerror = () => {
+                const msg = "Could not read the selected file. Please try a different image.";
+                if (typeof alertPrompt === "function") {
+                    alertPrompt(msg);
+                } else {
+                    alert(msg);
+                }
                 fileInput.value = "";
             };
             reader.readAsDataURL(selectedFile);
@@ -332,7 +352,6 @@ document.addEventListener("DOMContentLoaded", function () {
             customIconImg.alt = "";
             customIconImg.classList.add("custom-shortcut-icon");
             customIconImg.referrerPolicy = "no-referrer";
-            customIconImg.crossOrigin = "anonymous";
             customIconImg.addEventListener("error", () => {
                 customIconImg.src = "./svgs/offline.svg";
             }, { once: true });
@@ -678,6 +697,8 @@ document.addEventListener("DOMContentLoaded", function () {
                             // Clear from UI as well
                             const entry = entries[index];
                             if (entry) entry.querySelector(".iconURL").value = "";
+                            // Keep cache/render consistent with persisted state
+                            item.icon = "";
                         } else {
                             throw iconError;
                         }

--- a/scripts/shortcuts.js
+++ b/scripts/shortcuts.js
@@ -231,6 +231,8 @@ document.addEventListener("DOMContentLoaded", function () {
             reader.onload = () => {
                 iconInput.value = reader.result;
                 saveShortcut(entry);
+                
+                // Render with the current icon value (may be empty if quota was exceeded)
                 renderShortcut(
                     entry.querySelector(".shortcutName").value,
                     entry.querySelector(".URL").value,
@@ -297,6 +299,23 @@ document.addEventListener("DOMContentLoaded", function () {
         }[match]));
     }
 
+    // Validates custom icon URL for security
+    function isValidCustomIconUrl(url) {
+        if (!url || typeof url !== "string") return false;
+        
+        const trimmed = url.trim();
+        
+        if (trimmed.startsWith("data:image/")) {
+            return true;
+        }
+        
+        if (trimmed.startsWith("https://")) {
+            return true;
+        }
+        
+        return false;
+    }
+
     // Normalizes URLs to ensure they're valid
     function normalizeUrl(url) {
         url = url.trim();
@@ -307,17 +326,27 @@ document.addEventListener("DOMContentLoaded", function () {
 
     // Gets the appropriate logo HTML for a given URL
     function getLogoHtml(url, customIcon = "") {
-        const hostname = new URL(normalizeUrl(url)).hostname.replace(/^www\./, "");
-
-        if (customIcon && customIcon.trim()) {
+        if (customIcon && isValidCustomIconUrl(customIcon)) {
             const customIconImg = document.createElement("img");
             customIconImg.src = customIcon.trim();
             customIconImg.alt = "";
             customIconImg.classList.add("custom-shortcut-icon");
+            customIconImg.referrerPolicy = "no-referrer";
+            customIconImg.crossOrigin = "anonymous";
             customIconImg.addEventListener("error", () => {
                 customIconImg.src = "./svgs/offline.svg";
             }, { once: true });
             return customIconImg;
+        }
+
+        let hostname;
+        try {
+            hostname = new URL(normalizeUrl(url)).hostname.replace(/^www\./, "");
+        } catch (error) {
+            const offlineImg = document.createElement("img");
+            offlineImg.src = "./svgs/offline.svg";
+            offlineImg.alt = "";
+            return offlineImg;
         }
 
         // GitHub shortcut
@@ -341,6 +370,7 @@ document.addEventListener("DOMContentLoaded", function () {
 
         img.src = `https://s2.googleusercontent.com/s2/favicons?domain_url=https://${hostname}&sz=256`;
         img.alt = "";
+        img.referrerPolicy = "no-referrer";
 
         img.addEventListener("error", () => {
             img.src = "./svgs/offline.svg";
@@ -632,15 +662,41 @@ document.addEventListener("DOMContentLoaded", function () {
 
         // Only save if order has changed
         if (hasOrderChanged(newOrder)) {
-            localStorage.setItem("shortcutAmount", newOrder.length.toString());
-            newOrder.forEach((item, index) => {
-                localStorage.setItem(`shortcutName${index}`, item.name);
-                localStorage.setItem(`shortcutURL${index}`, item.url);
-                localStorage.setItem(`shortcutIcon${index}`, item.icon || "");
-            });
+            try {
+                localStorage.setItem("shortcutAmount", newOrder.length.toString());
+                newOrder.forEach((item, index) => {
+                    localStorage.setItem(`shortcutName${index}`, item.name);
+                    localStorage.setItem(`shortcutURL${index}`, item.url);
+                    
+                    // Try to save icon, skip/clear if quota exceeded
+                    try {
+                        localStorage.setItem(`shortcutIcon${index}`, item.icon || "");
+                    } catch (iconError) {
+                        if (iconError.name === "QuotaExceededError") {
+                            // Remove icon due to quota
+                            localStorage.removeItem(`shortcutIcon${index}`);
+                            // Clear from UI as well
+                            const entry = entries[index];
+                            if (entry) entry.querySelector(".iconURL").value = "";
+                        } else {
+                            throw iconError;
+                        }
+                    }
+                });
 
-            shortcutsCache = newOrder;
-            renderAllShortcuts(newOrder);
+                shortcutsCache = newOrder;
+                renderAllShortcuts(newOrder);
+            } catch (error) {
+                console.error("Error saving shortcut order:", error);
+                if (error.name === "QuotaExceededError") {
+                    const message = "Could not save all shortcuts: storage quota exceeded. Please remove some icons or clear storage.";
+                    if (typeof alertPrompt === "function") {
+                        alertPrompt(message);
+                    } else {
+                        alert(message);
+                    }
+                }
+            }
         }
     }
 
@@ -781,8 +837,45 @@ document.addEventListener("DOMContentLoaded", function () {
 
     // Saves a single shortcut to localStorage
     function saveShortcut(entry) {
-        localStorage.setItem(`shortcutName${entry._index}`, entry.querySelector(".shortcutName").value);
-        localStorage.setItem(`shortcutURL${entry._index}`, entry.querySelector(".URL").value);
-        localStorage.setItem(`shortcutIcon${entry._index}`, entry.querySelector(".iconURL").value || "");
+        const index = entry._index;
+        const name = entry.querySelector(".shortcutName").value;
+        const url = entry.querySelector(".URL").value;
+        const iconInput = entry.querySelector(".iconURL");
+        const icon = iconInput.value || "";
+
+        try {
+            localStorage.setItem(`shortcutName${index}`, name);
+            localStorage.setItem(`shortcutURL${index}`, url);
+            
+            // Try to save icon separately to handle quota errors gracefully
+            try {
+                localStorage.setItem(`shortcutIcon${index}`, icon);
+            } catch (iconError) {
+                if (iconError.name === "QuotaExceededError") {
+                    // Icon is too large, clear it from input and localStorage
+                    iconInput.value = "";
+                    localStorage.removeItem(`shortcutIcon${index}`);
+                    
+                    const message = "Icon could not be saved: storage quota exceeded. Please use a smaller icon file.";
+                    if (typeof alertPrompt === "function") {
+                        alertPrompt(message);
+                    } else {
+                        alert(message);
+                    }
+                } else {
+                    throw iconError;
+                }
+            }
+        } catch (error) {
+            console.error("Error saving shortcut:", error);
+            if (error.name !== "QuotaExceededError") {
+                const message = "Failed to save shortcut. Please check your browser storage.";
+                if (typeof alertPrompt === "function") {
+                    alertPrompt(message);
+                } else {
+                    alert(message);
+                }
+            }
+        }
     }
 });

--- a/scripts/shortcuts.js
+++ b/scripts/shortcuts.js
@@ -11,7 +11,8 @@ document.addEventListener("DOMContentLoaded", function () {
         name: "New shortcut",
         url: "https://github.com/prem-k-r/MaterialYouNewTab",
         inputName: "Shortcut Name",
-        inputUrl: "Shortcut URL"
+        inputUrl: "Shortcut URL",
+        inputIcon: "Custom Icon URL (optional)"
     };
 
     // DOM Elements
@@ -143,12 +144,13 @@ document.addEventListener("DOMContentLoaded", function () {
         for (let i = 0; i < amount; i++) {
             const name = localStorage.getItem(`shortcutName${i}`) || (presets[i] ? presets[i].name : PLACEHOLDER.name);
             const url = localStorage.getItem(`shortcutURL${i}`) || (presets[i] ? presets[i].url : PLACEHOLDER.url);
+            const icon = localStorage.getItem(`shortcutIcon${i}`) || "";
 
-            shortcutsCache.push({ name, url });
+            shortcutsCache.push({ name, url, icon });
 
-            const entry = createShortcutEntry(name, url, deleteInactive, i);
+            const entry = createShortcutEntry(name, url, icon, deleteInactive, i);
             dom.shortcutSettingsContainer.appendChild(entry);
-            renderShortcut(name, url, i);
+            renderShortcut(name, url, icon, i);
         }
 
         // Disable new shortcut button if max reached
@@ -160,7 +162,7 @@ document.addEventListener("DOMContentLoaded", function () {
     }
 
     // Creates a shortcut entry element for the settings panel
-    function createShortcutEntry(name, url, deleteInactive, index) {
+    function createShortcutEntry(name, url, iconUrl, deleteInactive, index) {
         const entry = document.createElement("div");
         entry.className = "shortcutSettingsEntry";
         entry.draggable = true;
@@ -177,21 +179,68 @@ document.addEventListener("DOMContentLoaded", function () {
                     <circle cy="13.5" cx="10.5" r=".75"/>
                 </svg>
             </div>
-            <div>
+            <div class="shortcutInputGroup">
                 <input class="shortcutName" placeholder="${PLACEHOLDER.inputName}" value="${escapeHtml(name)}">
                 <input class="URL" placeholder="${PLACEHOLDER.inputUrl}" value="${escapeHtml(url)}">
+                <input class="iconURL" placeholder="${PLACEHOLDER.inputIcon}" value="${escapeHtml(iconUrl || "")}">
             </div>
-            <div class="delete">
+            <div class="shortcutActions">
+                <button type="button" class="uploadCustomIconButton" aria-label="Upload custom icon" title="Upload custom icon">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                        <path d="M12 3v12"/>
+                        <path d="m8 7 4-4 4 4"/>
+                        <path d="M5 14v4a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2v-4"/>
+                    </svg>
+                </button>
+                <input type="file" class="iconFileInput" accept="image/*,.ico" hidden>
+                <div class="delete">
                 <button class="${deleteInactive ? 'inactive' : ''}">
                     <svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24">
                         <path d="M7.8 20.4q-.742 0-1.271-.529Q6 19.343 6 18.6v-12h-.3q-.383 0-.641-.257-.259-.258-.259-.638t.259-.643Q5.317 4.8 5.7 4.8h3.9v-.3q0-.383.259-.641.258-.259.641-.259h3q.383 0 .641.259.259.258.259.641v.3h3.9q.383 0 .641.257.259.257.259.638 0 .38-.259.643-.258.262-.641.262H18v11.99q0 .76-.529 1.285-.529.525-1.271.525Zm8.4-13.8H7.8v12h8.4zm-5.705 10.2q.38 0 .643-.259.262-.259.262-.641V9.3q0-.383-.257-.641-.258-.259-.638-.259t-.643.259Q9.6 8.917 9.6 9.3v6.6q0 .383.257.641.258.259.638.259Zm3 0q.38 0 .643-.259.262-.259.262-.641V9.3q0-.383-.257-.641-.258-.259-.638-.259t-.643.259q-.262.258-.262.641v6.6q0 .383.257.641.258.259.638.259ZM7.8 6.6v12z"/>
                     </svg>
                 </button>
             </div>
+            </div>
         `;
 
-        const inputs = entry.querySelectorAll("input");
+        const inputs = entry.querySelectorAll("input.shortcutName, input.URL, input.iconURL");
         attachInputListeners(inputs, entry);
+
+        const uploadButton = entry.querySelector(".uploadCustomIconButton");
+        const fileInput = entry.querySelector(".iconFileInput");
+        const iconInput = entry.querySelector(".iconURL");
+
+        uploadButton.addEventListener("click", () => fileInput.click());
+        fileInput.addEventListener("change", async e => {
+            const selectedFile = e.target.files?.[0];
+            if (!selectedFile) return;
+
+            const maxIconBytes = 350 * 1024;
+            if (selectedFile.size > maxIconBytes) {
+                const message = "Icon file is too large. Please use a file smaller than 350 KB.";
+                if (typeof alertPrompt === "function") {
+                    await alertPrompt(message);
+                } else {
+                    alert(message);
+                }
+                fileInput.value = "";
+                return;
+            }
+
+            const reader = new FileReader();
+            reader.onload = () => {
+                iconInput.value = reader.result;
+                saveShortcut(entry);
+                renderShortcut(
+                    entry.querySelector(".shortcutName").value,
+                    entry.querySelector(".URL").value,
+                    iconInput.value,
+                    entry._index
+                );
+                fileInput.value = "";
+            };
+            reader.readAsDataURL(selectedFile);
+        });
 
         const deleteBtn = entry.querySelector(".delete button");
         deleteBtn.addEventListener("click", () => deleteShortcut(entry));
@@ -199,7 +248,7 @@ document.addEventListener("DOMContentLoaded", function () {
         return entry;
     }
 
-    function createShortcutElement(name, url, index) {
+    function createShortcutElement(name, url, icon, index) {
         const normalizedUrl = normalizeUrl(url);
 
         const shortcut = document.createElement("div");
@@ -212,7 +261,7 @@ document.addEventListener("DOMContentLoaded", function () {
         const logoContainer = document.createElement("div");
         logoContainer.className = "shortcutLogoContainer";
 
-        const logo = getLogoHtml(normalizedUrl);
+        const logo = getLogoHtml(normalizedUrl, icon);
         if (logo) logoContainer.appendChild(logo);
 
         const span = document.createElement("span");
@@ -227,8 +276,8 @@ document.addEventListener("DOMContentLoaded", function () {
     }
 
     // Renders a shortcut in the main view
-    function renderShortcut(name, url, index) {
-        const shortcut = createShortcutElement(name, url, index);
+    function renderShortcut(name, url, icon, index) {
+        const shortcut = createShortcutElement(name, url, icon, index);
 
         if (index < dom.shortcutsContainer.children.length) {
             dom.shortcutsContainer.replaceChild(shortcut, dom.shortcutsContainer.children[index]);
@@ -257,8 +306,19 @@ document.addEventListener("DOMContentLoaded", function () {
     }
 
     // Gets the appropriate logo HTML for a given URL
-    function getLogoHtml(url) {
+    function getLogoHtml(url, customIcon = "") {
         const hostname = new URL(normalizeUrl(url)).hostname.replace(/^www\./, "");
+
+        if (customIcon && customIcon.trim()) {
+            const customIconImg = document.createElement("img");
+            customIconImg.src = customIcon.trim();
+            customIconImg.alt = "";
+            customIconImg.classList.add("custom-shortcut-icon");
+            customIconImg.addEventListener("error", () => {
+                customIconImg.src = "./svgs/offline.svg";
+            }, { once: true });
+            return customIconImg;
+        }
 
         // GitHub shortcut
         if (hostname === "github.com") {
@@ -297,6 +357,7 @@ document.addEventListener("DOMContentLoaded", function () {
                 renderShortcut(
                     entry.querySelector(".shortcutName").value,
                     entry.querySelector(".URL").value,
+                    entry.querySelector(".iconURL").value,
                     entry._index
                 );
             });
@@ -304,7 +365,8 @@ document.addEventListener("DOMContentLoaded", function () {
         });
 
         inputs[0].addEventListener("keydown", e => e.key === "Enter" && inputs[1].focus());
-        inputs[1].addEventListener("keydown", e => e.key === "Enter" && e.target.blur());
+        inputs[1].addEventListener("keydown", e => e.key === "Enter" && inputs[2].focus());
+        inputs[2].addEventListener("keydown", e => e.key === "Enter" && e.target.blur());
     }
 
     // Drag and drop functionality for reordering shortcuts
@@ -564,7 +626,8 @@ document.addEventListener("DOMContentLoaded", function () {
         const entries = dom.shortcutSettingsContainer.querySelectorAll(".shortcutSettingsEntry");
         const newOrder = Array.from(entries).map(entry => ({
             name: entry.querySelector(".shortcutName").value,
-            url: entry.querySelector(".URL").value
+            url: entry.querySelector(".URL").value,
+            icon: entry.querySelector(".iconURL").value
         }));
 
         // Only save if order has changed
@@ -573,6 +636,7 @@ document.addEventListener("DOMContentLoaded", function () {
             newOrder.forEach((item, index) => {
                 localStorage.setItem(`shortcutName${index}`, item.name);
                 localStorage.setItem(`shortcutURL${index}`, item.url);
+                localStorage.setItem(`shortcutIcon${index}`, item.icon || "");
             });
 
             shortcutsCache = newOrder;
@@ -586,7 +650,7 @@ document.addEventListener("DOMContentLoaded", function () {
 
         return newOrder.some((item, index) => {
             const cached = shortcutsCache[index];
-            return item.name !== cached.name || item.url !== cached.url;
+            return item.name !== cached.name || item.url !== cached.url || (item.icon || "") !== (cached.icon || "");
         });
     }
 
@@ -595,7 +659,7 @@ document.addEventListener("DOMContentLoaded", function () {
         const fragment = document.createDocumentFragment();
 
         order.forEach((item, index) => {
-            fragment.appendChild(createShortcutElement(item.name, item.url, index));
+            fragment.appendChild(createShortcutElement(item.name, item.url, item.icon, index));
         });
 
         dom.shortcutsContainer.innerHTML = "";
@@ -645,11 +709,11 @@ document.addEventListener("DOMContentLoaded", function () {
             dom.newShortcutButton.classList.add("inactive");
         }
 
-        const entry = createShortcutEntry(PLACEHOLDER.name, PLACEHOLDER.url, false, currentAmount);
+        const entry = createShortcutEntry(PLACEHOLDER.name, PLACEHOLDER.url, "", false, currentAmount);
         dom.shortcutSettingsContainer.appendChild(entry);
 
         saveShortcut(entry);
-        renderShortcut(PLACEHOLDER.name, PLACEHOLDER.url, currentAmount);
+        renderShortcut(PLACEHOLDER.name, PLACEHOLDER.url, "", currentAmount);
     }
 
     // Deletes a shortcut
@@ -670,6 +734,7 @@ document.addEventListener("DOMContentLoaded", function () {
         }
         localStorage.removeItem(`shortcutName${currentAmount - 1}`);
         localStorage.removeItem(`shortcutURL${currentAmount - 1}`);
+        localStorage.removeItem(`shortcutIcon${currentAmount - 1}`);
 
         if (currentAmount - 1 === 1) {
             document.querySelectorAll(".delete button").forEach(b => {
@@ -697,6 +762,7 @@ document.addEventListener("DOMContentLoaded", function () {
         for (let i = 0; i < (localStorage.getItem("shortcutAmount") || 0); i++) {
             localStorage.removeItem(`shortcutName${i}`);
             localStorage.removeItem(`shortcutURL${i}`);
+            localStorage.removeItem(`shortcutIcon${i}`);
         }
         localStorage.removeItem("shortcutAmount");
 
@@ -717,5 +783,6 @@ document.addEventListener("DOMContentLoaded", function () {
     function saveShortcut(entry) {
         localStorage.setItem(`shortcutName${entry._index}`, entry.querySelector(".shortcutName").value);
         localStorage.setItem(`shortcutURL${entry._index}`, entry.querySelector(".URL").value);
+        localStorage.setItem(`shortcutIcon${entry._index}`, entry.querySelector(".iconURL").value || "");
     }
 });

--- a/scripts/shortcuts.js
+++ b/scripts/shortcuts.js
@@ -243,7 +243,7 @@ document.addEventListener("DOMContentLoaded", function () {
                 }
             };
             reader.onerror = () => {
-                console.error("Failed to read selected file:", err);
+                console.error("Failed to read selected file:", reader.error);
                 fileInput.value = "";
             };
             reader.readAsDataURL(selectedFile);

--- a/scripts/shortcuts.js
+++ b/scripts/shortcuts.js
@@ -185,31 +185,30 @@ document.addEventListener("DOMContentLoaded", function () {
                 <input class="iconURL" placeholder="${PLACEHOLDER.inputIcon}" value="${escapeHtml(iconUrl || "")}">
             </div>
             <div class="shortcutActions">
-                <button type="button" class="uploadCustomIconButton" aria-label="Upload custom icon" title="Upload custom icon">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                        <path d="M12 3v12"/>
-                        <path d="m8 7 4-4 4 4"/>
-                        <path d="M5 14v4a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2v-4"/>
+                <button type="button" class="uploadCustomIconButton">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+                        <path d="M12 3.5a.89.89 0 0 0-.641.27l-3.57 3.571a.895.895 0 0 0 1.265 1.265l2.051-2.051v8.577a.895.895 0 1 0 1.79 0V6.555l2.051 2.051a.895.895 0 0 0 1.266-1.265l-3.57-3.57A.91.91 0 0 0 12 3.5m-6.263 9.842c-.494 0-.895.4-.895.895v3.579A2.7 2.7 0 0 0 7.526 20.5h8.948a2.7 2.7 0 0 0 2.684-2.684v-3.58a.895.895 0 1 0-1.79 0v3.58c0 .505-.39.895-.894.895H7.526a.88.88 0 0 1-.894-.895v-3.58c0-.493-.401-.894-.895-.894"/>
                     </svg>
                 </button>
-                <input type="file" class="iconFileInput" accept="image/*,.ico" hidden>
-                <div class="delete">
-                <button class="${deleteInactive ? 'inactive' : ''}">
-                    <svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24">
-                        <path d="M7.8 20.4q-.742 0-1.271-.529Q6 19.343 6 18.6v-12h-.3q-.383 0-.641-.257-.259-.258-.259-.638t.259-.643Q5.317 4.8 5.7 4.8h3.9v-.3q0-.383.259-.641.258-.259.641-.259h3q.383 0 .641.259.259.258.259.641v.3h3.9q.383 0 .641.257.259.257.259.638 0 .38-.259.643-.258.262-.641.262H18v11.99q0 .76-.529 1.285-.529.525-1.271.525Zm8.4-13.8H7.8v12h8.4zm-5.705 10.2q.38 0 .643-.259.262-.259.262-.641V9.3q0-.383-.257-.641-.258-.259-.638-.259t-.643.259Q9.6 8.917 9.6 9.3v6.6q0 .383.257.641.258.259.638.259Zm3 0q.38 0 .643-.259.262-.259.262-.641V9.3q0-.383-.257-.641-.258-.259-.638-.259t-.643.259q-.262.258-.262.641v6.6q0 .383.257.641.258.259.638.259ZM7.8 6.6v12z"/>
-                    </svg>
-                </button>
-            </div>
+                <input type="file" class="iconFileInput" accept="image/*" hidden>
+                <div class="shortcutDelete">
+                    <button class="${deleteInactive ? 'inactive' : ''}">
+                        <svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24">
+                            <path d="M7.8 20.4q-.742 0-1.271-.529Q6 19.343 6 18.6v-12h-.3q-.383 0-.641-.257-.259-.258-.259-.638t.259-.643Q5.317 4.8 5.7 4.8h3.9v-.3q0-.383.259-.641.258-.259.641-.259h3q.383 0 .641.259.259.258.259.641v.3h3.9q.383 0 .641.257.259.257.259.638 0 .38-.259.643-.258.262-.641.262H18v11.99q0 .76-.529 1.285-.529.525-1.271.525Zm8.4-13.8H7.8v12h8.4zm-5.705 10.2q.38 0 .643-.259.262-.259.262-.641V9.3q0-.383-.257-.641-.258-.259-.638-.259t-.643.259Q9.6 8.917 9.6 9.3v6.6q0 .383.257.641.258.259.638.259Zm3 0q.38 0 .643-.259.262-.259.262-.641V9.3q0-.383-.257-.641-.258-.259-.638-.259t-.643.259q-.262.258-.262.641v6.6q0 .383.257.641.258.259.638.259ZM7.8 6.6v12z"/>
+                        </svg>
+                    </button>
+                </div>
             </div>
         `;
 
         const inputs = entry.querySelectorAll("input.shortcutName, input.URL, input.iconURL");
-        attachInputListeners(inputs, entry);
-
         const uploadButton = entry.querySelector(".uploadCustomIconButton");
         const fileInput = entry.querySelector(".iconFileInput");
         const iconInput = entry.querySelector(".iconURL");
+        const deleteBtn = entry.querySelector(".shortcutDelete button");
 
+        attachInputListeners(inputs, entry);
+        // TODO: I've to Check!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
         uploadButton.addEventListener("click", () => fileInput.click());
         fileInput.addEventListener("change", async e => {
             const selectedFile = e.target.files?.[0];
@@ -218,11 +217,7 @@ document.addEventListener("DOMContentLoaded", function () {
             const maxIconBytes = 350 * 1024;
             if (selectedFile.size > maxIconBytes) {
                 const message = "Icon file is too large. Please use a file smaller than 350 KB.";
-                if (typeof alertPrompt === "function") {
-                    await alertPrompt(message);
-                } else {
-                    alert(message);
-                }
+                alertPrompt(message);
                 fileInput.value = "";
                 return;
             }
@@ -232,7 +227,7 @@ document.addEventListener("DOMContentLoaded", function () {
                 iconInput.value = reader.result;
                 try {
                     saveShortcut(entry);
-                    
+
                     // Render with the current icon value (may be empty if quota was exceeded)
                     renderShortcut(
                         entry.querySelector(".shortcutName").value,
@@ -242,11 +237,7 @@ document.addEventListener("DOMContentLoaded", function () {
                     );
                 } catch (err) {
                     const msg = "Unable to save the icon — storage is full. Try removing other custom icons or using a smaller image.";
-                    if (typeof alertPrompt === "function") {
-                        alertPrompt(msg);
-                    } else {
-                        alert(msg);
-                    }
+                    alertPrompt(msg);
                     iconInput.value = "";
                 } finally {
                     fileInput.value = "";
@@ -254,17 +245,12 @@ document.addEventListener("DOMContentLoaded", function () {
             };
             reader.onerror = () => {
                 const msg = "Could not read the selected file. Please try a different image.";
-                if (typeof alertPrompt === "function") {
-                    alertPrompt(msg);
-                } else {
-                    alert(msg);
-                }
+                alertPrompt(msg);
                 fileInput.value = "";
             };
             reader.readAsDataURL(selectedFile);
         });
 
-        const deleteBtn = entry.querySelector(".delete button");
         deleteBtn.addEventListener("click", () => deleteShortcut(entry));
 
         return entry;
@@ -283,7 +269,7 @@ document.addEventListener("DOMContentLoaded", function () {
         const logoContainer = document.createElement("div");
         logoContainer.className = "shortcutLogoContainer";
 
-        const logo = getLogoHtml(normalizedUrl, icon);
+        const logo = getLogoHtml(name, normalizedUrl, icon);
         if (logo) logoContainer.appendChild(logo);
 
         const span = document.createElement("span");
@@ -319,21 +305,11 @@ document.addEventListener("DOMContentLoaded", function () {
         }[match]));
     }
 
-    // Validates custom icon URL for security
+    // Validates custom icon URL
     function isValidCustomIconUrl(url) {
-        if (!url || typeof url !== "string") return false;
-        
+        if (typeof url !== "string") return false;
         const trimmed = url.trim();
-        
-        if (trimmed.startsWith("data:image/")) {
-            return true;
-        }
-        
-        if (trimmed.startsWith("https://")) {
-            return true;
-        }
-        
-        return false;
+        return trimmed.startsWith("data:image/") || trimmed.startsWith("https://") || trimmed.startsWith("http://");
     }
 
     // Normalizes URLs to ensure they're valid
@@ -345,27 +321,70 @@ document.addEventListener("DOMContentLoaded", function () {
     }
 
     // Gets the appropriate logo HTML for a given URL
-    function getLogoHtml(url, customIcon = "") {
+    function getLogoHtml(name, url, customIcon = "") {
+        let hostname;
+
+        function setIconType(element, type) {
+            element.setAttribute("data-icon-type", type);
+            return element;
+        }
+
+        function createLetterFallback() {
+            let letter = "?";
+
+            if (name.trim()) {
+                letter = name.trim().charAt(0).toUpperCase();
+            } else {
+                try {
+                    hostname = new URL(normalizeUrl(url)).hostname.replace(/^www\./, "");
+                    letter = hostname.charAt(0).toUpperCase() || "?";
+                } catch {
+                    letter = (url.trim()?.charAt(0) || "?").toUpperCase();
+                }
+            }
+
+            // TODO: MutationObserver to update colors when theme changes
+            const selectedTheme = localStorage.getItem("selectedTheme");
+            const color = selectedTheme === "dark"
+                ? "#bfbfbf"
+                : localStorage.getItem("accentLightTintColor") || "#ffffff";
+            const svg = `
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 50 50">
+                    <text x="50%" y="58%" text-anchor="middle" dominant-baseline="middle"
+                        font-size="30" font-family="Inter, Segoe UI, Arial, sans-serif" font-weight="700"
+                        fill="${color}">
+                        ${letter}
+                    </text>
+                </svg>
+            `;
+
+            const img = document.createElement("img");
+            img.src = "data:image/svg+xml;charset=utf-8," + encodeURIComponent(svg);
+            img.alt = "";
+            setIconType(img, "default");
+            return img;
+        }
+
         if (customIcon && isValidCustomIconUrl(customIcon)) {
             const customIconImg = document.createElement("img");
             customIconImg.src = customIcon.trim();
             customIconImg.alt = "";
             customIconImg.classList.add("custom-shortcut-icon");
             customIconImg.referrerPolicy = "no-referrer";
+            setIconType(customIconImg, "custom");
             customIconImg.addEventListener("error", () => {
-                customIconImg.src = "./svgs/offline.svg";
+                customIconImg.src = createLetterFallback().src;
+                customIconImg.classList.remove("custom-shortcut-icon");
+                customIconImg.classList.add("letter-shortcut-icon");
             }, { once: true });
+
             return customIconImg;
         }
 
-        let hostname;
         try {
             hostname = new URL(normalizeUrl(url)).hostname.replace(/^www\./, "");
         } catch (error) {
-            const offlineImg = document.createElement("img");
-            offlineImg.src = "./svgs/offline.svg";
-            offlineImg.alt = "";
-            return offlineImg;
+            return createLetterFallback();
         }
 
         // GitHub shortcut
@@ -373,6 +392,7 @@ document.addEventListener("DOMContentLoaded", function () {
             const img = document.createElement("img");
             img.src = "./svgs/github-shortcut.svg";
             img.alt = "";
+            setIconType(img, "default");
             return img;
         }
 
@@ -381,7 +401,9 @@ document.addEventListener("DOMContentLoaded", function () {
         if (preset) {
             const wrapper = document.createElement("div");
             wrapper.innerHTML = preset.svg;
-            return wrapper.firstElementChild;
+            const svgElement = wrapper.firstElementChild;
+            setIconType(svgElement, "default");
+            return svgElement;
         }
 
         // Fetch favicon from Google 
@@ -390,9 +412,10 @@ document.addEventListener("DOMContentLoaded", function () {
         img.src = `https://s2.googleusercontent.com/s2/favicons?domain_url=https://${hostname}&sz=256`;
         img.alt = "";
         img.referrerPolicy = "no-referrer";
-
+        setIconType(img, "default");
         img.addEventListener("error", () => {
-            img.src = "./svgs/offline.svg";
+            img.src = createLetterFallback().src;
+            img.classList.add("letter-shortcut-icon");
         }, { once: true });
 
         return img;
@@ -678,7 +701,7 @@ document.addEventListener("DOMContentLoaded", function () {
             url: entry.querySelector(".URL").value,
             icon: entry.querySelector(".iconURL").value
         }));
-
+        // TODO: I've to Check!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
         // Only save if order has changed
         if (hasOrderChanged(newOrder)) {
             try {
@@ -686,7 +709,7 @@ document.addEventListener("DOMContentLoaded", function () {
                 newOrder.forEach((item, index) => {
                     localStorage.setItem(`shortcutName${index}`, item.name);
                     localStorage.setItem(`shortcutURL${index}`, item.url);
-                    
+
                     // Try to save icon, skip/clear if quota exceeded
                     try {
                         localStorage.setItem(`shortcutIcon${index}`, item.icon || "");
@@ -711,11 +734,7 @@ document.addEventListener("DOMContentLoaded", function () {
                 console.error("Error saving shortcut order:", error);
                 if (error.name === "QuotaExceededError") {
                     const message = "Could not save all shortcuts: storage quota exceeded. Please remove some icons or clear storage.";
-                    if (typeof alertPrompt === "function") {
-                        alertPrompt(message);
-                    } else {
-                        alert(message);
-                    }
+                    alertPrompt(message);
                 }
             }
         }
@@ -777,7 +796,7 @@ document.addEventListener("DOMContentLoaded", function () {
         localStorage.setItem("shortcutAmount", newAmount.toString());
 
         if (currentAmount >= 1) {
-            document.querySelectorAll(".delete button.inactive").forEach(b => {
+            document.querySelectorAll(".shortcutDelete button.inactive").forEach(b => {
                 b.classList.remove("inactive");
             });
         }
@@ -814,7 +833,7 @@ document.addEventListener("DOMContentLoaded", function () {
         localStorage.removeItem(`shortcutIcon${currentAmount - 1}`);
 
         if (currentAmount - 1 === 1) {
-            document.querySelectorAll(".delete button").forEach(b => {
+            document.querySelectorAll(".shortcutDelete button").forEach(b => {
                 b.classList.add("inactive");
             });
         }
@@ -863,11 +882,11 @@ document.addEventListener("DOMContentLoaded", function () {
         const url = entry.querySelector(".URL").value;
         const iconInput = entry.querySelector(".iconURL");
         const icon = iconInput.value || "";
-
+        // TODO: I've to Check!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
         try {
             localStorage.setItem(`shortcutName${index}`, name);
             localStorage.setItem(`shortcutURL${index}`, url);
-            
+
             // Try to save icon separately to handle quota errors gracefully
             try {
                 localStorage.setItem(`shortcutIcon${index}`, icon);
@@ -876,13 +895,9 @@ document.addEventListener("DOMContentLoaded", function () {
                     // Icon is too large, clear it from input and localStorage
                     iconInput.value = "";
                     localStorage.removeItem(`shortcutIcon${index}`);
-                    
+
                     const message = "Icon could not be saved: storage quota exceeded. Please use a smaller icon file.";
-                    if (typeof alertPrompt === "function") {
-                        alertPrompt(message);
-                    } else {
-                        alert(message);
-                    }
+                    alertPrompt(message);
                 } else {
                     throw iconError;
                 }
@@ -891,11 +906,7 @@ document.addEventListener("DOMContentLoaded", function () {
             console.error("Error saving shortcut:", error);
             if (error.name !== "QuotaExceededError") {
                 const message = "Failed to save shortcut. Please check your browser storage.";
-                if (typeof alertPrompt === "function") {
-                    alertPrompt(message);
-                } else {
-                    alert(message);
-                }
+                alertPrompt(message);
             }
         }
     }

--- a/scripts/shortcuts.js
+++ b/scripts/shortcuts.js
@@ -171,12 +171,12 @@ document.addEventListener("DOMContentLoaded", function () {
         entry.innerHTML = `
             <div class="grip-container" draggable="true">
                 <svg stroke="currentColor" width="18" height="18" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5">
-                    <circle cy="2.5" cx="5.5" r=".75"/>
+                    <circle cy="2" cx="5.5" r=".75"/>
                     <circle cy="8" cx="5.5" r=".75"/>
-                    <circle cy="13.5" cx="5.5" r=".75"/>
-                    <circle cy="2.5" cx="10.5" r=".75"/>
+                    <circle cy="14" cx="5.5" r=".75"/>
+                    <circle cy="2" cx="10.5" r=".75"/>
                     <circle cy="8" cx="10.5" r=".75"/>
-                    <circle cy="13.5" cx="10.5" r=".75"/>
+                    <circle cy="14" cx="10.5" r=".75"/>
                 </svg>
             </div>
             <div class="shortcutInputGroup">
@@ -208,16 +208,17 @@ document.addEventListener("DOMContentLoaded", function () {
         const deleteBtn = entry.querySelector(".shortcutDelete button");
 
         attachInputListeners(inputs, entry);
-        // TODO: I've to Check!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
         uploadButton.addEventListener("click", () => fileInput.click());
         fileInput.addEventListener("change", async e => {
             const selectedFile = e.target.files?.[0];
             if (!selectedFile) return;
 
-            const maxIconBytes = 350 * 1024;
+            const maxIconBytes = 100 * 1024;
             if (selectedFile.size > maxIconBytes) {
-                const message = "Icon file is too large. Please use a file smaller than 350 KB.";
-                alertPrompt(message);
+                const iconFileTooLargeMessage = translations[currentLanguage]?.iconFileTooLargeMessage || translations["en"].iconFileTooLargeMessage;
+                const fileSizeKB = (selectedFile.size / 1024).toFixed(1);
+                alertPrompt(iconFileTooLargeMessage.replace("{size}", `${fileSizeKB} KB`));
                 fileInput.value = "";
                 return;
             }
@@ -227,7 +228,6 @@ document.addEventListener("DOMContentLoaded", function () {
                 iconInput.value = reader.result;
                 try {
                     saveShortcut(entry);
-
                     // Render with the current icon value (may be empty if quota was exceeded)
                     renderShortcut(
                         entry.querySelector(".shortcutName").value,
@@ -236,16 +236,14 @@ document.addEventListener("DOMContentLoaded", function () {
                         entry._index
                     );
                 } catch (err) {
-                    const msg = "Unable to save the icon — storage is full. Try removing other custom icons or using a smaller image.";
-                    alertPrompt(msg);
+                    console.error("Failed to save icon:", err);
                     iconInput.value = "";
                 } finally {
                     fileInput.value = "";
                 }
             };
             reader.onerror = () => {
-                const msg = "Could not read the selected file. Please try a different image.";
-                alertPrompt(msg);
+                console.error("Failed to read selected file:", err);
                 fileInput.value = "";
             };
             reader.readAsDataURL(selectedFile);
@@ -297,19 +295,25 @@ document.addEventListener("DOMContentLoaded", function () {
     // Escapes HTML to prevent XSS
     function escapeHtml(unsafe) {
         return unsafe.replace(/[&<>"']/g, match => ({
-            '&': '&amp;',
-            '<': '&lt;',
-            '>': '&gt;',
-            '"': '&quot;',
-            "'": '&#39;'
+            "&": "&amp;",
+            "<": "&lt;",
+            ">": "&gt;",
+            '"': "&quot;",
+            "'": "&#39;",
         }[match]));
     }
 
     // Validates custom icon URL
     function isValidCustomIconUrl(url) {
         if (typeof url !== "string") return false;
-        const trimmed = url.trim();
-        return trimmed.startsWith("data:image/") || trimmed.startsWith("https://") || trimmed.startsWith("http://");
+        const trimmedUrl = url.trim();
+        if (trimmedUrl.includes(" ")) return false;
+        const lowercaseUrl = trimmedUrl.toLowerCase();
+        return (
+            lowercaseUrl.startsWith("data:image/") ||
+            lowercaseUrl.startsWith("https://") ||
+            lowercaseUrl.startsWith("http://")
+        );
     }
 
     // Normalizes URLs to ensure they're valid
@@ -406,7 +410,7 @@ document.addEventListener("DOMContentLoaded", function () {
             return svgElement;
         }
 
-        // Fetch favicon from Google 
+        // Fetch favicon from Google
         const img = document.createElement("img");
 
         img.src = `https://s2.googleusercontent.com/s2/favicons?domain_url=https://${hostname}&sz=256`;
@@ -453,7 +457,7 @@ document.addEventListener("DOMContentLoaded", function () {
         // Cache element positions for smooth gliding animation
         function cachePositions() {
             const map = new Map();
-            const entries = dom.shortcutSettingsContainer.querySelectorAll('.shortcutSettingsEntry');
+            const entries = dom.shortcutSettingsContainer.querySelectorAll(".shortcutSettingsEntry");
             for (const el of entries) {
                 map.set(el, el.getBoundingClientRect().top);
             }
@@ -480,11 +484,11 @@ document.addEventListener("DOMContentLoaded", function () {
                 if (oldTop !== undefined && newTop !== undefined) {
                     const delta = oldTop - newTop;
                     if (delta !== 0) {
-                        el.style.transition = 'none';
+                        el.style.transition = "none";
                         el.style.transform = `translateY(${delta}px)`;
                         requestAnimationFrame(() => {
-                            el.style.transition = 'transform 300ms cubic-bezier(0.4, 0, 0.2, 1)';
-                            el.style.transform = 'none';
+                            el.style.transition = "transform 300ms cubic-bezier(0.4, 0, 0.2, 1)";
+                            el.style.transform = "none";
                         });
                     }
                 }
@@ -555,7 +559,7 @@ document.addEventListener("DOMContentLoaded", function () {
             while (low <= high) {
                 const mid = (low + high) >>> 1;
                 const middleY = elements[mid].rect.top + elements[mid].rect.height / 2;
-                y < middleY ? high = mid - 1 : low = mid + 1;
+                y < middleY ? (high = mid - 1) : (low = mid + 1);
             }
 
             return elements[low]?.element || null;
@@ -701,26 +705,23 @@ document.addEventListener("DOMContentLoaded", function () {
             url: entry.querySelector(".URL").value,
             icon: entry.querySelector(".iconURL").value
         }));
-        // TODO: I've to Check!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
         // Only save if order has changed
         if (hasOrderChanged(newOrder)) {
-            try {
-                localStorage.setItem("shortcutAmount", newOrder.length.toString());
-                newOrder.forEach((item, index) => {
-                    localStorage.setItem(`shortcutName${index}`, item.name);
-                    localStorage.setItem(`shortcutURL${index}`, item.url);
+            localStorage.setItem("shortcutAmount", newOrder.length.toString());
+            newOrder.forEach((item, index) => {
+                localStorage.setItem(`shortcutName${index}`, item.name);
+                localStorage.setItem(`shortcutURL${index}`, item.url);
 
-                    // Try to save icon, skip/clear if quota exceeded
-                    try {
-                        localStorage.setItem(`shortcutIcon${index}`, item.icon || "");
-                    } catch (iconError) {
-                        if (iconError.name === "QuotaExceededError") {
+                // Try to save icon, skip/clear if quota exceeded
+                try {
+                    localStorage.setItem(`shortcutIcon${index}`, item.icon || "");
+                } catch (iconError) {
+                        if (iconError.name === "QuotaExceededError" || iconError.code === 22) {
                             // Remove icon due to quota
                             localStorage.removeItem(`shortcutIcon${index}`);
-                            // Clear from UI as well
                             const entry = entries[index];
                             if (entry) entry.querySelector(".iconURL").value = "";
-                            // Keep cache/render consistent with persisted state
                             item.icon = "";
                         } else {
                             throw iconError;
@@ -728,15 +729,8 @@ document.addEventListener("DOMContentLoaded", function () {
                     }
                 });
 
-                shortcutsCache = newOrder;
-                renderAllShortcuts(newOrder);
-            } catch (error) {
-                console.error("Error saving shortcut order:", error);
-                if (error.name === "QuotaExceededError") {
-                    const message = "Could not save all shortcuts: storage quota exceeded. Please remove some icons or clear storage.";
-                    alertPrompt(message);
-                }
-            }
+            shortcutsCache = newOrder;
+            renderAllShortcuts(newOrder);
         }
     }
 
@@ -847,7 +841,7 @@ document.addEventListener("DOMContentLoaded", function () {
             return;
 
         // Animation for shortcut elements
-        const shortcutEntries = [...dom.shortcutSettingsContainer.querySelectorAll('.shortcutSettingsEntry')];
+        const shortcutEntries = [...dom.shortcutSettingsContainer.querySelectorAll(".shortcutSettingsEntry")];
         shortcutEntries.forEach(el => el.classList.add("reset-shift-animation"));
 
         // Animation for reset button
@@ -882,31 +876,23 @@ document.addEventListener("DOMContentLoaded", function () {
         const url = entry.querySelector(".URL").value;
         const iconInput = entry.querySelector(".iconURL");
         const icon = iconInput.value || "";
-        // TODO: I've to Check!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+        localStorage.setItem(`shortcutName${index}`, name);
+        localStorage.setItem(`shortcutURL${index}`, url);
+
+        // Try to save icon separately to handle quota errors gracefully
         try {
-            localStorage.setItem(`shortcutName${index}`, name);
-            localStorage.setItem(`shortcutURL${index}`, url);
+            localStorage.setItem(`shortcutIcon${index}`, icon);
+        } catch (iconError) {
+            if (iconError.name === "QuotaExceededError" || iconError.code === 22) {
+                // Icon is too large, clear it from input and localStorage
+                iconInput.value = "";
+                localStorage.removeItem(`shortcutIcon${index}`);
 
-            // Try to save icon separately to handle quota errors gracefully
-            try {
-                localStorage.setItem(`shortcutIcon${index}`, icon);
-            } catch (iconError) {
-                if (iconError.name === "QuotaExceededError") {
-                    // Icon is too large, clear it from input and localStorage
-                    iconInput.value = "";
-                    localStorage.removeItem(`shortcutIcon${index}`);
-
-                    const message = "Icon could not be saved: storage quota exceeded. Please use a smaller icon file.";
-                    alertPrompt(message);
-                } else {
-                    throw iconError;
-                }
-            }
-        } catch (error) {
-            console.error("Error saving shortcut:", error);
-            if (error.name !== "QuotaExceededError") {
-                const message = "Failed to save shortcut. Please check your browser storage.";
-                alertPrompt(message);
+                const iconStorageQuotaMessage = translations[currentLanguage]?.iconStorageQuotaMessage || translations["en"].iconStorageQuotaMessage;
+                alertPrompt(iconStorageQuotaMessage);
+            } else {
+                throw iconError;
             }
         }
     }

--- a/scripts/shortcuts.js
+++ b/scripts/shortcuts.js
@@ -365,7 +365,6 @@ document.addEventListener("DOMContentLoaded", function () {
             const img = document.createElement("img");
             img.src = "data:image/svg+xml;charset=utf-8," + encodeURIComponent(svg);
             img.alt = "";
-            setIconType(img, "default");
             return img;
         }
 
@@ -373,13 +372,11 @@ document.addEventListener("DOMContentLoaded", function () {
             const customIconImg = document.createElement("img");
             customIconImg.src = customIcon.trim();
             customIconImg.alt = "";
-            customIconImg.classList.add("custom-shortcut-icon");
             customIconImg.referrerPolicy = "no-referrer";
             setIconType(customIconImg, "custom");
             customIconImg.addEventListener("error", () => {
                 customIconImg.src = createLetterFallback().src;
-                customIconImg.classList.remove("custom-shortcut-icon");
-                customIconImg.classList.add("letter-shortcut-icon");
+                setIconType(customIconImg, "letter");
             }, { once: true });
 
             return customIconImg;
@@ -419,7 +416,7 @@ document.addEventListener("DOMContentLoaded", function () {
         setIconType(img, "default");
         img.addEventListener("error", () => {
             img.src = createLetterFallback().src;
-            img.classList.add("letter-shortcut-icon");
+            setIconType(customIconImg, "letter");
         }, { once: true });
 
         return img;

--- a/scripts/theme.js
+++ b/scripts/theme.js
@@ -171,6 +171,8 @@ function changeFaviconColor() {
     const rootStyles = getComputedStyle(document.documentElement);
     const darkColor = rootStyles.getPropertyValue("--darkColor-blue");
     //const bgColor = rootStyles.getPropertyValue("--bg-color-blue");
+    let accentLightTintColor = rootStyles.getPropertyValue("--accentLightTint-blue");
+    localStorage.setItem("accentLightTintColor", accentLightTintColor);
 
     const svg = `
     <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">

--- a/style.css
+++ b/style.css
@@ -3517,14 +3517,14 @@ input:checked + .toggle:before {
 .shortcutSettingsEntry {
 	width: 100%;
 	display: flex;
-	height: 68px;
 	justify-content: space-between;
-	align-items: center;
+	align-items: flex-start;
 	margin-bottom: 16px;
 	background-color: var(--bg-color-blue);
 	border-radius: 13px;
-	padding: 15px 10px;
+	padding: 12px 10px;
 	padding-inline-start: 8px;
+	gap: 10px;
 	position: relative;
 	transition: transform 0.3s var(--md-motion-ease) opacity 0.2s ease;
 	/* Enable hardware acceleration */
@@ -3580,13 +3580,13 @@ input:checked + .toggle:before {
 
 .grip-container {
 	display: flex;
-	align-items: center;
+	align-items: flex-start;
 	justify-content: center;
-	height: 54px;
-	padding: 0 6px;
+	padding: 4px 6px;
 	cursor: grab;
 	color: var(--textColor);
 	opacity: 0.5;
+	min-height: 40px;
 }
 
 .grip-container:hover {
@@ -3651,21 +3651,24 @@ input:checked + .toggle:before {
 	transition: 0.3s all;
 }
 
-.uploadCustomIconButton:not(.inactive):hover {
+/* Shared hover state for action buttons */
+.uploadCustomIconButton:not(.inactive):hover,
+.delete button:not(.inactive):hover {
 	fill: white;
-	color: white;
 	background: var(--darkColor-blue);
+}
+
+/* Color-specific hover for upload button */
+.uploadCustomIconButton:not(.inactive):hover {
+	color: white;
 }
 
 .uploadCustomIconButton svg {
 	pointer-events: none;
 }
 
-.delete button:not(.inactive):hover {
-	fill: white;
-	background: var(--darkColor-blue);
-}
-
+/* Shared inactive state for action buttons */
+.uploadCustomIconButton.inactive,
 .delete button.inactive {
 	opacity: 0.5;
 	cursor: not-allowed;
@@ -3694,7 +3697,7 @@ input:checked + .toggle:before {
 	height: 50px;
 	display: flex;
 	justify-content: space-between;
-	background: color-mix(in srgb, var(--darkColor-blue) 14%, transparent);
+	margin-top: 19px;
 	gap: 20px;
 }
 
@@ -5144,18 +5147,20 @@ body[data-bg="wallpaper"] .dropdown-content {
 	fill: var(--textColorDark-dark);
 }
 
-.black-theme .uploadCustomIconButton:not(.inactive):hover {
+/* Shared dark-theme hover for action buttons */
+.black-theme .uploadCustomIconButton:not(.inactive):hover,
+.black-theme .delete button:hover {
 	background: #404040;
+}
+
+/* Color-specific dark-theme hover for upload button */
+.black-theme .uploadCustomIconButton:not(.inactive):hover {
 	color: var(--whitishColor-dark);
 	fill: var(--whitishColor-dark);
 }
 
 .black-theme .delete button {
 	background: #232221;
-}
-
-.black-theme .delete button:hover {
-	background: #404040;
 }
 
 .black-theme .prompt-modal-ok {

--- a/style.css
+++ b/style.css
@@ -2543,6 +2543,16 @@ body[data-bg="wallpaper"] .shortcuts .shortcut-name {
 	mix-blend-mode: normal;
 }
 
+.shortcutsContainer .shortcuts .shortcutLogoContainer img.custom-shortcut-icon {
+	height: 80%;
+	width: 80%;
+	border-radius: 20%;
+	object-fit: contain;
+	background: transparent;
+	filter: none;
+	mix-blend-mode: normal;
+}
+
 /* Adaptive Icons styling */
 .adaptive-icons .shortcuts .shortcutLogoContainer img {
 	height: calc(100% * 0.7071) !important;
@@ -3521,6 +3531,14 @@ input:checked + .toggle:before {
 	will-change: transform, opacity;
 }
 
+.shortcutInputGroup {
+	flex: 1;
+	min-width: 0;
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+}
+
 .shortcutSettingsEntry:last-child {
 	margin-bottom: 0;
 }
@@ -3542,6 +3560,12 @@ input:checked + .toggle:before {
 	font-size: 0.84rem;
 	opacity: 0.9;
 	margin-top: -3px;
+}
+
+.shortcutSettingsEntry .iconURL {
+	font-size: 0.76rem;
+	opacity: 0.9;
+	margin-top: -2px;
 }
 
 /* Drag and drop styles */
@@ -3591,6 +3615,13 @@ input:checked + .toggle:before {
 	transform: none;
 }
 
+.shortcutActions {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	margin-inline-start: 10px;
+}
+
 .delete button {
 	fill: var(--textColorDark-blue);
 	display: flex;
@@ -3603,6 +3634,31 @@ input:checked + .toggle:before {
 	border-radius: 7px;
 	cursor: pointer;
 	transition: 0.3s all;
+}
+
+.uploadCustomIconButton {
+	fill: var(--textColorDark-blue);
+	color: var(--textColorDark-blue);
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 46px;
+	height: 46px;
+	background: rgba(255, 255, 255, 0.4);
+	border: none;
+	border-radius: 7px;
+	cursor: pointer;
+	transition: 0.3s all;
+}
+
+.uploadCustomIconButton:not(.inactive):hover {
+	fill: white;
+	color: white;
+	background: var(--darkColor-blue);
+}
+
+.uploadCustomIconButton svg {
+	pointer-events: none;
 }
 
 .delete button:not(.inactive):hover {
@@ -3638,7 +3694,7 @@ input:checked + .toggle:before {
 	height: 50px;
 	display: flex;
 	justify-content: space-between;
-	margin-top: 19px;
+	background: color-mix(in srgb, var(--darkColor-blue) 14%, transparent);
 	gap: 20px;
 }
 
@@ -5080,6 +5136,18 @@ body[data-bg="wallpaper"] .dropdown-content {
 
 .black-theme .shortcutSettingsEntry {
 	background-color: var(--bg-color-dark);
+}
+
+.black-theme .uploadCustomIconButton {
+	background: #232221;
+	color: var(--textColorDark-dark);
+	fill: var(--textColorDark-dark);
+}
+
+.black-theme .uploadCustomIconButton:not(.inactive):hover {
+	background: #404040;
+	color: var(--whitishColor-dark);
+	fill: var(--whitishColor-dark);
 }
 
 .black-theme .delete button {

--- a/style.css
+++ b/style.css
@@ -2582,6 +2582,21 @@ body[data-bg="wallpaper"] .shortcuts .shortcut-name {
 	mix-blend-mode: screen;
 }
 
+.adaptive-icons .shortcuts .shortcutLogoContainer img.custom-shortcut-icon {
+	height: 60%;
+	width: 60%;
+	border-radius: 20%;
+	object-fit: contain;
+	background: transparent;
+	filter: none !important;
+	mix-blend-mode: normal !important;
+}
+
+.adaptive-icons .shortcuts .shortcutLogoContainer img.letter-shortcut-icon {
+	height: 100% !important;
+	width: 100% !important;
+}
+
 html:has(.themeSegment[data-active="dark"])
 	.adaptive-icons
 	.shortcuts
@@ -3570,7 +3585,7 @@ input:checked + .toggle:before {
 	width: 100%;
 	display: flex;
 	justify-content: space-between;
-	align-items: flex-start;
+	align-items: center;
 	margin-bottom: 16px;
 	background-color: var(--bg-color-blue);
 	border-radius: 13px;
@@ -3632,7 +3647,7 @@ input:checked + .toggle:before {
 
 .grip-container {
 	display: flex;
-	align-items: flex-start;
+	align-items: center;
 	justify-content: center;
 	padding: 4px 6px;
 	cursor: grab;
@@ -3674,7 +3689,7 @@ input:checked + .toggle:before {
 	margin-inline-start: 10px;
 }
 
-.delete button {
+.shortcutDelete button {
 	fill: var(--textColorDark-blue);
 	display: flex;
 	align-items: center;
@@ -3705,7 +3720,7 @@ input:checked + .toggle:before {
 
 /* Shared hover state for action buttons */
 .uploadCustomIconButton:not(.inactive):hover,
-.delete button:not(.inactive):hover {
+.shortcutDelete button:not(.inactive):hover {
 	fill: white;
 	background: var(--darkColor-blue);
 }
@@ -3721,7 +3736,7 @@ input:checked + .toggle:before {
 
 /* Shared inactive state for action buttons */
 .uploadCustomIconButton.inactive,
-.delete button.inactive {
+.shortcutDelete button.inactive {
 	opacity: 0.5;
 	cursor: not-allowed;
 }
@@ -5220,18 +5235,18 @@ body[data-bg="wallpaper"] .dropdown-content {
 }
 
 /* Shared dark-theme hover for action buttons */
-.black-theme .uploadCustomIconButton:not(.inactive):hover,
-.black-theme .delete button:hover {
+.black-theme .uploadCustomIconButton:hover,
+.black-theme .shortcutDelete button:hover {
 	background: #404040;
 }
 
 /* Color-specific dark-theme hover for upload button */
-.black-theme .uploadCustomIconButton:not(.inactive):hover {
+.black-theme .uploadCustomIconButton:hover {
 	color: var(--whitishColor-dark);
 	fill: var(--whitishColor-dark);
 }
 
-.black-theme .delete button {
+.black-theme .shortcutDelete button {
 	background: #232221;
 }
 

--- a/style.css
+++ b/style.css
@@ -2559,20 +2559,18 @@ body[data-bg="wallpaper"] .shortcuts .shortcut-name {
 .shortcutsContainer .shortcuts .shortcutLogoContainer img {
 	height: 100%;
 	width: 100%;
-	border-radius: 100%;
+	border-radius: 50%;
+	object-fit: contain;
 	filter: none;
 	mix-blend-mode: normal;
 }
 
-.shortcutsContainer .shortcuts .shortcutLogoContainer img.custom-shortcut-icon {
-	height: 80%;
-	width: 80%;
-	border-radius: 20%;
+/* .shortcutsContainer .shortcuts .shortcutLogoContainer img.custom-shortcut-icon {
 	object-fit: contain;
 	background: transparent;
 	filter: none;
 	mix-blend-mode: normal;
-}
+} */
 
 /* Adaptive Icons styling */
 .adaptive-icons .shortcuts .shortcutLogoContainer img {
@@ -2582,20 +2580,15 @@ body[data-bg="wallpaper"] .shortcuts .shortcut-name {
 	mix-blend-mode: screen;
 }
 
-.adaptive-icons .shortcuts .shortcutLogoContainer img.custom-shortcut-icon {
-	height: 60%;
-	width: 60%;
-	border-radius: 20%;
-	object-fit: contain;
-	background: transparent;
+/* .adaptive-icons .shortcuts .shortcutLogoContainer img.custom-shortcut-icon {
 	filter: none !important;
 	mix-blend-mode: normal !important;
-}
+}*/
 
 .adaptive-icons .shortcuts .shortcutLogoContainer img.letter-shortcut-icon {
 	height: 100% !important;
 	width: 100% !important;
-}
+} 
 
 html:has(.themeSegment[data-active="dark"])
 	.adaptive-icons
@@ -3589,9 +3582,8 @@ input:checked + .toggle:before {
 	margin-bottom: 16px;
 	background-color: var(--bg-color-blue);
 	border-radius: 13px;
-	padding: 12px 10px;
+	padding: 8px 10px;
 	padding-inline-start: 8px;
-	gap: 10px;
 	position: relative;
 	transition: transform 0.3s var(--md-motion-ease) opacity 0.2s ease;
 	/* Enable hardware acceleration */
@@ -3604,6 +3596,8 @@ input:checked + .toggle:before {
 	display: flex;
 	flex-direction: column;
 	justify-content: center;
+	margin: 0 8px 0 6px;
+	gap: 1px;
 }
 
 .shortcutSettingsEntry:last-child {
@@ -3611,10 +3605,9 @@ input:checked + .toggle:before {
 }
 
 .shortcutSettingsEntry input {
-	width: calc(100% - 18px);
+	width: 100%;
 	background: none;
 	border: none;
-	margin-inline-start: 8px;
 	color: var(--textColorDark-blue);
 	text-overflow: ellipsis;
 }
@@ -3624,15 +3617,14 @@ input:checked + .toggle:before {
 }
 
 .shortcutSettingsEntry .URL {
-	font-size: 0.84rem;
+	font-size: 0.8rem;
 	opacity: 0.9;
-	margin-top: -3px;
+	margin-top: -2px;
 }
 
 .shortcutSettingsEntry .iconURL {
-	font-size: 0.76rem;
+	font-size: 0.7rem;
 	opacity: 0.9;
-	margin-top: -2px;
 }
 
 /* Drag and drop styles */
@@ -3649,11 +3641,11 @@ input:checked + .toggle:before {
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	padding: 4px 6px;
+	padding: 12px 6px;
 	cursor: grab;
 	color: var(--textColor);
 	opacity: 0.5;
-	min-height: 40px;
+	height: 50px;
 }
 
 .grip-container:hover {
@@ -3661,12 +3653,13 @@ input:checked + .toggle:before {
 }
 
 .grip-container svg {
+	transform: scale(1.1);
 	pointer-events: none;
 	transition: transform 0.2s ease;
 }
 
 .grip-container:hover svg {
-	transform: scale(1.1);
+	transform: scale(1.2);
 }
 
 .shortcutSettingsEntry.dragging .grip-container {
@@ -3686,26 +3679,12 @@ input:checked + .toggle:before {
 	display: flex;
 	align-items: center;
 	gap: 8px;
-	margin-inline-start: 10px;
+	margin-inline-start: 8px;
 }
 
-.shortcutDelete button {
-	fill: var(--textColorDark-blue);
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	width: 46px;
-	height: 46px;
-	background: rgba(255, 255, 255, 0.4);
-	border: none;
-	border-radius: 7px;
-	cursor: pointer;
-	transition: 0.3s all;
-}
-
+.shortcutDelete button,
 .uploadCustomIconButton {
 	fill: var(--textColorDark-blue);
-	color: var(--textColorDark-blue);
 	display: flex;
 	align-items: center;
 	justify-content: center;

--- a/style.css
+++ b/style.css
@@ -236,7 +236,7 @@ html:has(
 	& #darkTheme,
 	& .favicon,
 	& #wIcon,
-	&:not(:has(#adaptiveIconToggle:checked)) .shortcutLogoContainer img {
+	&:not(:has(#adaptiveIconToggle:checked)) .shortcutLogoContainer img[data-icon-type="default"] {
 		filter: invert(1) hue-rotate(180deg);
 		-webkit-filter: invert(1) hue-rotate(180deg);
 	}
@@ -276,7 +276,7 @@ body[data-bg="wallpaper"][sysTheme="systemDark"]:has(
 	& #darkTheme,
 	& .favicon,
 	& #wIcon,
-	&:not(:has(#adaptiveIconToggle:checked)) .shortcutLogoContainer img {
+	&:not(:has(#adaptiveIconToggle:checked)) .shortcutLogoContainer img[data-icon-type="default"] {
 		filter: invert(1) hue-rotate(180deg);
 		-webkit-filter: invert(1) hue-rotate(180deg);
 	}
@@ -2565,56 +2565,68 @@ body[data-bg="wallpaper"] .shortcuts .shortcut-name {
 	mix-blend-mode: normal;
 }
 
-/* .shortcutsContainer .shortcuts .shortcutLogoContainer img.custom-shortcut-icon {
-	object-fit: contain;
-	background: transparent;
-	filter: none;
-	mix-blend-mode: normal;
-} */
-
 /* Adaptive Icons styling */
-.adaptive-icons .shortcuts .shortcutLogoContainer img {
+.adaptive-icons .shortcuts .shortcutLogoContainer img[data-icon-type="default"] {
 	height: calc(100% * 0.7071) !important;
 	width: calc(100% * 0.7071) !important;
 	filter: grayscale(1);
 	mix-blend-mode: screen;
 }
 
-/* .adaptive-icons .shortcuts .shortcutLogoContainer img.custom-shortcut-icon {
-	filter: none !important;
-	mix-blend-mode: normal !important;
-}*/
-
-.adaptive-icons .shortcuts .shortcutLogoContainer img.letter-shortcut-icon {
-	height: 100% !important;
-	width: 100% !important;
-} 
-
 html:has(.themeSegment[data-active="dark"])
 	.adaptive-icons
 	.shortcuts
 	.shortcutLogoContainer
-	img,
+	img[data-icon-type="default"],
 html:has(body[sysTheme="systemDark"] .themeSegment[data-active="system"])
 	.adaptive-icons
 	.shortcuts
 	.shortcutLogoContainer
-	img {
+	img[data-icon-type="default"] {
 	filter: grayscale(1) invert(1);
 }
 
 body[data-bg="wallpaper"]:has(.themeSegment[data-active="dark"])
 	.adaptive-icons
 	.shortcutLogoContainer
-	img,
+	img[data-icon-type="default"],
 body[data-bg="wallpaper"][sysTheme="systemDark"]:has(
 		.themeSegment[data-active="system"]
 	)
 	.adaptive-icons
 	.shortcutLogoContainer
-	img {
+	img[data-icon-type="default"] {
 	filter: grayscale(1) invert(1) !important;
 }
+
+.shortcutLogoContainer img[data-icon-type="custom"] {
+    filter: none !important;
+    mix-blend-mode: normal !important;
+}
+
+html:has(.themeSegment[data-active="dark"])
+    .shortcuts .shortcutLogoContainer img[data-icon-type="custom"],
+html:has(body[sysTheme="systemDark"] .themeSegment[data-active="system"])
+    .shortcuts .shortcutLogoContainer img[data-icon-type="custom"],
+body[data-bg="wallpaper"]:has(.themeSegment[data-active="dark"])
+    .shortcuts .shortcutLogoContainer img[data-icon-type="custom"],
+body[data-bg="wallpaper"][sysTheme="systemDark"]:has(.themeSegment[data-active="system"])
+    .shortcuts .shortcutLogoContainer img[data-icon-type="custom"] {
+    filter: invert(1) hue-rotate(180deg) !important;
+    mix-blend-mode: normal !important;
+}
+
+.adaptive-icons .shortcuts .shortcutLogoContainer img[data-icon-type="custom"] {
+    height: calc(100% * 0.7071) !important;
+    width: calc(100% * 0.7071) !important;
+}
+
+.adaptive-icons .shortcuts .shortcutLogoContainer img[data-icon-type="letter"] {
+	height: 100% !important;
+	width: 100% !important;
+	filter: none !important;
+    mix-blend-mode: normal !important;
+} 
 /* ----------end of Shortcuts----------------- */
 
 /* -----------Ai-Tools----------------- */
@@ -5207,26 +5219,16 @@ body[data-bg="wallpaper"] .dropdown-content {
 	background-color: var(--bg-color-dark);
 }
 
+.black-theme .shortcutDelete button,
 .black-theme .uploadCustomIconButton {
 	background: #232221;
 	color: var(--textColorDark-dark);
 	fill: var(--textColorDark-dark);
 }
 
-/* Shared dark-theme hover for action buttons */
 .black-theme .uploadCustomIconButton:hover,
 .black-theme .shortcutDelete button:hover {
 	background: #404040;
-}
-
-/* Color-specific dark-theme hover for upload button */
-.black-theme .uploadCustomIconButton:hover {
-	color: var(--whitishColor-dark);
-	fill: var(--whitishColor-dark);
-}
-
-.black-theme .shortcutDelete button {
-	background: #232221;
 }
 
 .black-theme .prompt-modal-ok {

--- a/style.css
+++ b/style.css
@@ -2573,26 +2573,23 @@ body[data-bg="wallpaper"] .shortcuts .shortcut-name {
 	mix-blend-mode: screen;
 }
 
-html:has(.themeSegment[data-active="dark"])
+html:has(.themeSegment[data-active="dark"]):not(:has(#darkTheme:checked))
 	.adaptive-icons
 	.shortcuts
 	.shortcutLogoContainer
 	img[data-icon-type="default"],
-html:has(body[sysTheme="systemDark"] .themeSegment[data-active="system"])
+html:has(body[sysTheme="systemDark"] .themeSegment[data-active="system"]):not(:has(#darkTheme:checked))
 	.adaptive-icons
 	.shortcuts
 	.shortcutLogoContainer
-	img[data-icon-type="default"] {
-	filter: grayscale(1) invert(1);
-}
-
-body[data-bg="wallpaper"]:has(.themeSegment[data-active="dark"])
+	img[data-icon-type="default"],
+body[data-bg="wallpaper"]:has(.themeSegment[data-active="dark"]):not(:has(#darkTheme:checked))
 	.adaptive-icons
 	.shortcutLogoContainer
 	img[data-icon-type="default"],
 body[data-bg="wallpaper"][sysTheme="systemDark"]:has(
 		.themeSegment[data-active="system"]
-	)
+	):not(:has(#darkTheme:checked))
 	.adaptive-icons
 	.shortcutLogoContainer
 	img[data-icon-type="default"] {
@@ -2604,13 +2601,13 @@ body[data-bg="wallpaper"][sysTheme="systemDark"]:has(
     mix-blend-mode: normal !important;
 }
 
-html:has(.themeSegment[data-active="dark"])
+html:has(.themeSegment[data-active="dark"]):not(:has(#darkTheme:checked))
     .shortcuts .shortcutLogoContainer img[data-icon-type="custom"],
-html:has(body[sysTheme="systemDark"] .themeSegment[data-active="system"])
+html:has(body[sysTheme="systemDark"] .themeSegment[data-active="system"]):not(:has(#darkTheme:checked))
     .shortcuts .shortcutLogoContainer img[data-icon-type="custom"],
-body[data-bg="wallpaper"]:has(.themeSegment[data-active="dark"])
+body[data-bg="wallpaper"]:has(.themeSegment[data-active="dark"]):not(:has(#darkTheme:checked))
     .shortcuts .shortcutLogoContainer img[data-icon-type="custom"],
-body[data-bg="wallpaper"][sysTheme="systemDark"]:has(.themeSegment[data-active="system"])
+body[data-bg="wallpaper"][sysTheme="systemDark"]:has(.themeSegment[data-active="system"]):not(:has(#darkTheme:checked))
     .shortcuts .shortcutLogoContainer img[data-icon-type="custom"] {
     filter: invert(1) hue-rotate(180deg) !important;
     mix-blend-mode: normal !important;
@@ -2627,6 +2624,7 @@ body[data-bg="wallpaper"][sysTheme="systemDark"]:has(.themeSegment[data-active="
 	filter: none !important;
     mix-blend-mode: normal !important;
 } 
+
 /* ----------end of Shortcuts----------------- */
 
 /* -----------Ai-Tools----------------- */
@@ -5222,8 +5220,6 @@ body[data-bg="wallpaper"] .dropdown-content {
 .black-theme .shortcutDelete button,
 .black-theme .uploadCustomIconButton {
 	background: #232221;
-	color: var(--textColorDark-dark);
-	fill: var(--textColorDark-dark);
 }
 
 .black-theme .uploadCustomIconButton:hover,

--- a/style.css
+++ b/style.css
@@ -2599,6 +2599,7 @@ body[data-bg="wallpaper"][sysTheme="systemDark"]:has(
 .shortcutLogoContainer img[data-icon-type="custom"] {
     filter: none !important;
     mix-blend-mode: normal !important;
+	border-radius: 10% !important;
 }
 
 html:has(.themeSegment[data-active="dark"]):not(:has(#darkTheme:checked))


### PR DESCRIPTION
## 📌 Description

Added a way to upload custom images for shortcut icons from local files or public URL. Limited the file size with 350 KB.

## 🎨 Visual Changes (Screenshots / Videos)

<img width="620" height="104" alt="image" src="https://github.com/user-attachments/assets/ce74fe46-b704-48f0-84db-8668736b455c" />
<br/>
<img width="536" height="245" alt="image" src="https://github.com/user-attachments/assets/06eb810c-bd68-4643-abe1-7d3b0a7a69ae" />
<br/>
<img width="526" height="792" alt="image" src="https://github.com/user-attachments/assets/ee3ef661-8ea9-4598-ab8f-08fd8a732457" />

## 🔗 Related Issues

- Closes #<issue_number> <!-- if this PR fixes an issue -->
- Related to #<issue_number> <!-- if applicable -->

## ✅ Checklist

<!-- Tip: To mark a checklist item as complete, replace [ ] with [x] -->

- [x] I have read and followed the [Contributing Guidelines](https://github.com/prem-k-r/MaterialYouNewTab/blob/main/CONTRIBUTING.md).
- [x] My code follows the project's coding style and conventions.
- [x] I have tested my changes thoroughly to ensure expected behavior.
- [x] I have verified compatibility across Chrome and Edge (did not test in Firefox, because I don't use it).
- [x] I have attached relevant visual evidence (screenshots/videos) if applicable.
- [x] I have updated the [CHANGELOG.md](https://github.com/prem-k-r/MaterialYouNewTab/blob/main/CHANGELOG.md) under the appropriate categories with all my changes in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
This PR adds per-shortcut custom icons (upload from local file or public HTTPS URL), integrates an upload UI into shortcut settings, enforces a client-side 350 KB file-size limit with a user-facing error dialog, persists custom icons in localStorage under `shortcutIcon{i}`, preserves existing favicon/preset behavior when no custom icon is present, and improves fallback behavior (letter-based SVG when custom icon fails). It includes UI/UX styling updates, i18n additions, small theme persistence, quota-handling, and screenshots; work-in-progress commits remain.

## Changes Made

### Core Functionality (scripts/shortcuts.js)
- Adds end-to-end per-shortcut custom icon support: settings include an icon input (`icon`/`iconURL`), in-memory cache stores `{name, url, icon}`, and persistence uses `shortcutIcon{i}` keys in localStorage.
- Upload workflow: hidden file input + upload button; selected images converted to Data URLs and validated against a 350 KB limit. Oversize uploads trigger the file-size error dialog.
- Rendering: `getLogoHtml(name, url, customIcon)` now accepts a `customIcon` and, when valid (`data:image/*` or `https://`), renders an <img> with `referrerPolicy="no-referrer"` and a one-time error handler that falls back to a letter-based SVG (the letter fallback was added). Existing favicon/preset logic remains when no custom icon is set.
- Save/load/delete/reset flows updated to read/write/remove `shortcutIcon{i}`. Reordering/drag persistence includes icon values.
- Quota handling: attempts to handle localStorage QuotaExceeded by clearing stored icon entries, updating UI, and alerting the user when storage fails.
- Keyboard navigation: Enter-key focus order extended to include the new icon input.
- Error handling: alerts on save failures; icon load errors fall back to letter SVG or offline fallback.

### Styling (style.css)
- Adjusted shortcut logo image rules (border-radius changed to 50%; `object-fit: contain`) and added styles for letter-fallback icons.
- Reworked shortcut settings layout: removed fixed height, introduced `.shortcutInputGroup`, `.shortcutActions`, and `.iconURL` rules.
- Added `.uploadCustomIconButton` styles (hover/disabled), unified action button styling, and dark-theme overrides.
- Grip/drag-handle alignment and min-height adjusted.

### Internationalization & Language Application
- locales/en.js: adds i18n keys for icon file-too-large and storage-quota error messages (and small object formatting change).
- scripts/languages.js: `applyLanguage(lang)` now applies the new translation keys to corresponding DOM elements.

### Theme Persistence
- scripts/theme.js: `changeFaviconColor()` now also stores `--accentLightTint-blue` value into localStorage as `accentLightTintColor`.

### Documentation
- CHANGELOG.md updated under Unreleased → Added with the custom icon feature entry; also documents improved fallback/letter behavior in Improved section.

## Behavior & Technical Notes
- Client-side file-size limit: 350 KB enforced; oversized uploads show a modal error dialog.
- Custom icons accepted as Data URLs (from upload) or public HTTPS URLs; rendered with `referrerPolicy="no-referrer"`.
- On custom icon load failure, the UI falls back to a generated first-letter SVG (colored by theme/accent) or offline SVG as appropriate.
- LocalStorage quota errors are handled with attempts to clear stored icons and user notification.
- Feature tested on Chrome and Edge (not Firefox); PR includes screenshots demonstrating icons row, file-size error dialog, and saved shortcuts UI.
- Commits include WIP markers; author added a letter-fallback commit.

## Files / Areas with Notable Changes
- scripts/shortcuts.js — major update (+226/-48), high review effort (core logic, persistence, UI wiring).
- style.css — substantial styling changes (+~80/-7), affects shortcut visuals and settings layout.
- locales/en.js, scripts/languages.js — small i18n additions.
- scripts/theme.js — small addition to persist accent tint color.
- CHANGELOG.md — small documentation addition.

## Review Notes
- High-review areas: shortcuts.js (persistence, quota handling, icon load/fallback), style.css (visual/layout impacts).
- Confirm expected cross-browser behavior (Firefox not tested per PR description).
- Check consistency of i18n message sizes/units and ensure UI elements exist for new translation keys.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->