### PR TITLE
Feat  google ai studio

### DIFF
--- a/index.html
+++ b/index.html
@@ -1026,6 +1026,16 @@
                 <div class="tLabel" id="gemini">Gemini</div>
             </a>
             <!-- ---------------- -->
+            <a href="https://ai.google/studio/">
+                <div class="tIcon">
+                    <svg height="100%" viewBox="0 0 24 24" width="100%" xmlns="http://www.w3.org/2000/svg">
+                        <rect class="accentColor aiDarkIcons" width="100%" height="100%" rx="50%" />
+                        <path class="bgLightTint notTargeted" d="M12 4.5c-4.142 0-7.5 3.358-7.5 7.5S7.858 19.5 12 19.5 19.5 16.142 19.5 12 16.142 4.5 12 4.5zm0 1.5c1.854 0 3.5.894 4.5 2.296A4.497 4.497 0 0012 8.5c-1.97 0-3.657 1.23-4.27 2.963A5.993 5.993 0 0112 6zm0 11c-1.854 0-3.5-.894-4.5-2.296A4.497 4.497 0 0012 15.5c1.97 0 3.657-1.23 4.27-2.963A5.993 5.993 0 0112 17z" />
+                    </svg>
+                </div>
+                <div class="tLabel" id="googleAIStudio">Google AI Studio</div>
+            </a>
+            <!-- ---------------- -->
             <a href="https://copilot.microsoft.com/">
                 <div class="tIcon">
                     <svg height="100%" width="100%" viewBox="0 0 30 30" xmlns="http://www.w3.org/2000/svg">

--- a/locales/en.js
+++ b/locales/en.js
@@ -146,6 +146,7 @@ const en = {
     "ai_tools": "AI Tools",
     "chatGPT": "ChatGPT",
     "gemini": "Gemini",
+    "googleAIStudio": "Google AI Studio",
     "copilot": "Copilot",
     "claude": "Claude",
     "grok": "Grok",

--- a/scripts/ai-tools.js
+++ b/scripts/ai-tools.js
@@ -10,20 +10,53 @@
 const aiToolsRaw = [
     { id: "chatGPT", visible: true, order: 0 },
     { id: "gemini", visible: true, order: 1 },
-    { id: "copilot", visible: true, order: 2 },
-    { id: "claude", visible: true, order: 3 },
-    { id: "deepseek", visible: true, order: 4 },
-    { id: "perplexity", visible: false, order: 5 },
-    { id: "grok", visible: false, order: 6 },
-    { id: "metaAI", visible: false, order: 7 },
-    { id: "qwen", visible: false, order: 8 },
-    { id: "firefly", visible: false, order: 9 }
+    { id: "googleAIStudio", visible: true, order: 2 },
+    { id: "copilot", visible: true, order: 3 },
+    { id: "claude", visible: true, order: 4 },
+    { id: "deepseek", visible: true, order: 5 },
+    { id: "perplexity", visible: false, order: 6 },
+    { id: "grok", visible: false, order: 7 },
+    { id: "metaAI", visible: false, order: 8 },
+    { id: "qwen", visible: false, order: 9 },
+    { id: "firefly", visible: false, order: 10 }
 ];
 // Translations for AI tools
 const aiTools = aiToolsRaw.map(tool => ({
     ...tool,
     label: translations[currentLanguage]?.[tool.id] || translations["en"][tool.id]
 }));
+
+function mergeAIToolsSettings(savedSettings) {
+    const normalizedSettings = [];
+    const seenToolIds = new Set();
+
+    if (Array.isArray(savedSettings)) {
+        savedSettings.forEach((item) => {
+            let toolId;
+            let isVisible = true;
+
+            if (typeof item === "string") {
+                toolId = item;
+            } else {
+                toolId = Object.keys(item)[0];
+                isVisible = false;
+            }
+
+            if (aiTools.some(tool => tool.id === toolId)) {
+                seenToolIds.add(toolId);
+                normalizedSettings.push(isVisible ? toolId : { [toolId]: false });
+            }
+        });
+    }
+
+    aiTools.forEach((tool) => {
+        if (!seenToolIds.has(tool.id)) {
+            normalizedSettings.push(tool.visible ? tool.id : { [tool.id]: false });
+        }
+    });
+
+    return normalizedSettings;
+}
 
 // DOM Elements
 const aiToolName = document.getElementById("toolsCont");
@@ -131,12 +164,10 @@ function applyAIToolsSettings() {
     const savedSettings = JSON.parse(localStorage.getItem("aiToolsSettings") || "null");
     let settingsToApply;
 
-    if (!savedSettings || !Array.isArray(savedSettings)) {
-        // Initialize with default values if no settings exist
-        settingsToApply = aiTools.map(tool => tool.visible ? tool.id : { [tool.id]: false });
+    settingsToApply = mergeAIToolsSettings(savedSettings);
+
+    if (!savedSettings || !Array.isArray(savedSettings) || JSON.stringify(settingsToApply) !== JSON.stringify(savedSettings)) {
         localStorage.setItem("aiToolsSettings", JSON.stringify(settingsToApply));
-    } else {
-        settingsToApply = savedSettings;
     }
 
     // Create a map of current tool elements for quick lookup
@@ -243,23 +274,11 @@ function showAIToolsSettings() {
     aiToolsForm.innerHTML = "";
 
     // Load saved tool order and visibility or initialize from defaults
-    let savedSettings = JSON.parse(localStorage.getItem("aiToolsSettings") || "null");
-
-    // If no settings exist, create from aiTools
-    if (!savedSettings || !Array.isArray(savedSettings)) {
-        savedSettings = aiTools.map(tool => {
-            if (tool.visible) {
-                return tool.id;
-            } else {
-                const hiddenTool = {};
-                hiddenTool[tool.id] = false;
-                return hiddenTool;
-            }
-        });
-    }
+    const savedSettings = JSON.parse(localStorage.getItem("aiToolsSettings") || "null");
+    const normalizedSettings = mergeAIToolsSettings(savedSettings);
 
     // Generate the form with the saved settings
-    generateAIToolsForm(savedSettings);
+    generateAIToolsForm(normalizedSettings);
 
     // Show modal and overlay
     aiToolsSettingsModal.style.display = "block";


### PR DESCRIPTION
## 📌 Description

This PR adds Google AI Studio as a quick-access AI tool in the dashboard

## 🎨 Visual Changes (Screenshots / Videos)


<img width="1919" height="1023" alt="image" src="https://github.com/user-attachments/assets/8f356344-3a69-4bff-ae98-8cf0fd4b0b17" />


## 🔗 Related Issues


New Feature #177 

## ✅ Checklist



- [x] I have read and followed the [Contributing Guidelines](https://github.com/prem-k-r/MaterialYouNewTab/blob/main/CONTRIBUTING.md).
- [x] My code follows the project's coding style and conventions.
- [x] I have tested my changes thoroughly to ensure expected behavior.
- [x] I have verified compatibility across Chrome and Firefox (additional browsers if applicable).
- [x] I have attached relevant visual evidence (screenshots/videos) if applicable.
- [x] I have updated the [CHANGELOG.md](https://github.com/prem-k-r/MaterialYouNewTab/blob/main/CHANGELOG.md) under the appropriate categories with all my changes in this PR.




## Overview
Adds Google AI Studio as a new quick-access AI tool in the AI Tools navigation bar, alongside existing tools like ChatGPT, Gemini, and Claude.

## Changes

**index.html**
- Added a new AI Tools shortcut entry linking to `https://ai.google/studio/` with icon and label (`id="googleAIStudio"`), positioned after the existing Gemini entry

**locales/en.js**
- Added English localization string `googleAIStudio: "Google AI Studio"` in the AI Tools section

**scripts/ai-tools.js**
- Updated the default AI tool registry to include `googleAIStudio` at `order: 2`, shifting subsequent tools' order values accordingly
- Added `mergeAIToolsSettings(savedSettings)` helper function to normalize persisted localStorage settings by filtering unknown tool IDs, deduplicating entries, and appending missing tools from current defaults
- Modified `applyAIToolsSettings()` to use the new normalization helper and persist updated normalized arrays to localStorage with deep-compare validation
- Modified `showAIToolsSettings()` to use `mergeAIToolsSettings()` for initialization instead of prior fallback logic

## Related Issue
Implements New Feature #177

## Testing
Author verified changes across Chrome and Firefox browsers

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
This PR adds Google AI Studio as a new quick-access AI tool to the dashboard, implementing feature #177. Changes include a new UI shortcut, English localization, and updates to the AI tools registry with refactored settings management logic.

## Changes

**index.html**
- Added new `<a href="https://ai.google/studio/">` entry in the AI Tools shortcuts section with a label element `id="googleAIStudio"` and icon SVG, positioned after Gemini and before Copilot.

**locales/en.js**
- Added English localization: `"googleAIStudio": "Google AI Studio"` in the AI Tools section.

**scripts/ai-tools.js**
- Updated default AI tool registry: inserted `{ id: "googleAIStudio", visible: true, order: 2 }`, shifting order values for subsequent tools (`copilot`, `claude`, `deepseek`) and preserving other entries.
- Added `mergeAIToolsSettings(savedSettings)` to normalize persisted `aiToolsSettings` by:
  - Filtering unknown tool IDs
  - Deduplicating entries
  - Interpreting string entries as visible tools and object entries as hidden tools
  - Appending any missing tools from current defaults
- Modified `applyAIToolsSettings()` to compute normalized settings via `mergeAIToolsSettings()` and only persist to localStorage when the normalized result differs from stored data (deep-compare using JSON.stringify).
- Modified `showAIToolsSettings()` to initialize the settings form using `mergeAIToolsSettings()` instead of the prior fallback logic.
- Other integrations: `applyAIToolsSettings()` is invoked on DOMContentLoaded and after saving settings; `showAIToolsSettings()` is used by the AI Tools edit button.

## Testing
Author verified changes across Chrome and Firefox.

## Checklist
Contributing guidelines, coding style, testing, browser compatibility, visuals, and CHANGELOG update items marked complete by author.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->