### PR TITLE
Prevented shortcut icons from being color-inverted in dark mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Introduced collapsible sections in the settings menu for improved organization and easier navigation ([@prem-k-r](https://github.com/prem-k-r)) ([#109](https://github.com/prem-k-r/MaterialYouNewTab/pull/109))
 - Redesigned the theme selector from dropdown to buttons for easier switching between Light, Dark, and System modes ([@prem-k-r](https://github.com/prem-k-r)) ([#112](https://github.com/prem-k-r/MaterialYouNewTab/pull/112))
 - Added expanding animations to todo and Google apps panels and some other minor UI changes ([@prem-k-r](https://github.com/prem-k-r)) ([#118](https://github.com/prem-k-r/MaterialYouNewTab/pull/118))
+- Prevented weather condition and shortcut icons from being color-inverted in dark mode ([@prem-k-r](https://github.com/prem-k-r)) ([#191](https://github.com/prem-k-r/MaterialYouNewTab/pull/191))
 
 ### Fixed
 

--- a/style.css
+++ b/style.css
@@ -234,7 +234,9 @@ html:has(
 	-webkit-filter: invert(1) hue-rotate(180deg);
 
 	& #darkTheme,
-	& .favicon {
+	& .favicon,
+	& #wIcon,
+	&:not(:has(#adaptiveIconToggle:checked)) .shortcutLogoContainer img {
 		filter: invert(1) hue-rotate(180deg);
 		-webkit-filter: invert(1) hue-rotate(180deg);
 	}
@@ -272,7 +274,9 @@ body[data-bg="wallpaper"][sysTheme="systemDark"]:has(
 	-webkit-filter: invert(1) hue-rotate(180deg);
 
 	& #darkTheme,
-	& .favicon {
+	& .favicon,
+	& #wIcon,
+	&:not(:has(#adaptiveIconToggle:checked)) .shortcutLogoContainer img {
 		filter: invert(1) hue-rotate(180deg);
 		-webkit-filter: invert(1) hue-rotate(180deg);
 	}
@@ -2566,6 +2570,14 @@ body[data-bg="wallpaper"] .shortcuts .shortcut-name {
 	width: calc(100% * 0.7071) !important;
 	filter: grayscale(1);
 	mix-blend-mode: screen;
+}
+
+html:has(.themeSegment[data-active="dark"])
+	.adaptive-icons
+	.shortcuts
+	.shortcutLogoContainer
+	img {
+	filter: grayscale(1) invert(1);
 }
 /* ----------end of Shortcuts----------------- */
 


### PR DESCRIPTION
Prevented weather condition and shortcut icons from being color-inverted in dark mode

Full changes: e24ed73c1b9a0518c4a91e29970bcfbd54107e30

Closes #157




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Description

Prevents weather condition and shortcut icons from being color-inverted in dark mode by refining CSS filter rules for specific icon elements.

## Changes

**CHANGELOG.md**
- Added entry in the Unreleased → Improved section noting that weather condition and shortcut icons are no longer color-inverted in dark mode

**style.css**
- Extended dark-theme CSS selectors within `html:has(...)` rules to exclude specific icons from the global `invert(1) hue-rotate(180deg)` filter
- Added filter exemptions for:
  - `#wIcon` (weather icon)
  - `img` elements within `.shortcutLogoContainer` when adaptive icon toggle is not active
- Added new rule for adaptive icons: applies `filter: grayscale(1) invert(1)` to `.adaptive-icons .shortcuts .shortcutLogoContainer img` when dark mode is active, allowing adaptive icons to maintain visibility while preserving their intended appearance

## Impact

Resolves the issue where shortcut and weather icons would appear color-inverted when switching the extension theme from light to dark mode, ensuring icons retain their original colors across theme changes while maintaining adequate visibility in dark mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->