### PR TITLE
Fix: prevent wallpaper disappearing due to early URL revoke

### DIFF
--- a/scripts/wallpaper.js
+++ b/scripts/wallpaper.js
@@ -157,9 +157,6 @@ function checkAndUpdateImage() {
                 document.body.style.setProperty("--bg-image", `url(${imageUrl})`);
                 toggleBackgroundType(true);
             }
-
-            // Clean up the Blob URL after setting the background
-            setTimeout(() => URL.revokeObjectURL(imageUrl), 1500);
         })
         .catch((error) => {
             console.error("Error loading image details:", error);


### PR DESCRIPTION
## 📌 Description

Fixes wallpaper disappearing issue caused by premature revocation of Blob URL.

The background image was set using a Blob URL, but it was revoked shortly after being applied. Since CSS continues to rely on this URL for rendering, revoking it can result the wallpaper to disappear during later repaints (tab switch, memory cleanup).

This PR removes the early URL.revokeObjectURL call to ensure the background remains stable.

## 🔗 Related Issues

- Closes #169 <!-- if this PR fixes an issue -->
- Related to #169 <!-- if applicable -->

## ✅ Checklist

<!-- Tip: To mark a checklist item as complete, replace [ ] with [x] -->

- [x] I have read and followed the [Contributing Guidelines](https://github.com/prem-k-r/MaterialYouNewTab/blob/main/CONTRIBUTING.md).
- [x] My code follows the project's coding style and conventions.
- [x] I have tested my changes thoroughly to ensure expected behavior.
- [ ] I have verified compatibility across Chrome and Firefox (additional browsers if applicable).
- [ ] I have attached relevant visual evidence (screenshots/videos) if applicable.
- [ ] I have updated the [CHANGELOG.md](https://github.com/prem-k-r/MaterialYouNewTab/blob/main/CHANGELOG.md) under the appropriate categories with all my changes in this PR.

## 🤖 AI Assistance (Coding)

- [ ] None  
- [ ] Ideas / planning  
- [x] Debugging / review help  
- [ ] Small code snippets  
- [ ] Partial implementation  
- [ ] Major implementation help  
- [ ] Mostly AI-generated  
- [ ] Full vibe coded


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Fixes wallpaper disappearing due to premature Blob URL revocation

Resolves issue #169 where user-set custom wallpapers would disappear after several days of browser usage. The root cause was that when re-applying a saved wallpaper on the same day, the `checkAndUpdateImage()` function would create a Blob URL from the stored image blob and then immediately schedule its revocation via a delayed `URL.revokeObjectURL()` call. Since the CSS background property maintains only a reference to the URL string rather than the underlying blob data, revoking the URL would invalidate that resource, causing the wallpaper to disappear.

**Change:** Removed the delayed `URL.revokeObjectURL()` call from the `checkAndUpdateImage()` function when re-applying the same day's saved wallpaper. The Blob URL is now kept alive for the duration of the page session, allowing the CSS background to continue referencing it without interruption.

**Other flows preserved:** The URL revocation behavior is maintained in other code paths where appropriate (e.g., after uploading a new wallpaper or fetching a new random image).

**Impact:** User-set wallpapers now persist correctly throughout browser sessions without reverting to default or blank backgrounds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->