### PR TITLE
fix(wallpaper): Revoke blob URL only after new one is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project partially follows [Semantic Versioning](https://semver.org/spec
 
 - Fixed an issue where rapid clicks on the AI Tools icon caused race conditions, leading to inconsistent shortcuts panel visibility. ([@prem-k-r](https://github.com/prem-k-r)) ([#118](https://github.com/prem-k-r/MaterialYouNewTab/pull/118))
 - Fixed shortcut name and URLs hover behavior by replacing ellipsis with clipped text for improved readability ([@prem-k-r](https://github.com/prem-k-r)) ([283f78d](https://github.com/prem-k-r/MaterialYouNewTab/pull/199/changes/283f78d6e4b202a075ca3d670c1b30cbc701c3a4))
+- Fixed wallpaper disappearing on load due to blob URL being revoked too early ([@prem-k-r](https://github.com/prem-k-r)) ([#209](https://github.com/prem-k-r/MaterialYouNewTab/pull/209))
 
 ### Localized
 

--- a/scripts/wallpaper.js
+++ b/scripts/wallpaper.js
@@ -1,6 +1,6 @@
 /*
- * Material You NewTab
- * Copyright (c) 2023-2025 XengShi
+ * Material You New Tab
+ * Copyright (c) 2024-2026 Prem, 2023-2025 XengShi
  * Licensed under the GNU General Public License v3.0 (GPL-3.0)
  * You should have received a copy of the GNU General Public License along with this program.
  * If not, see <https://www.gnu.org/licenses/>.
@@ -12,6 +12,19 @@ const dbName = "ImageDB";
 const storeName = "backgroundImages";
 const timestampKey = "lastUpdateTime"; // Key to store last update time
 const imageTypeKey = "imageType"; // Key to store the type of image ("random" or "upload")
+
+let currentBgUrl = null;
+
+// To set background image using a Blob
+function setBackground(blob) {
+    if (currentBgUrl) {
+        URL.revokeObjectURL(currentBgUrl);
+    }
+    const newUrl = URL.createObjectURL(blob);
+    currentBgUrl = newUrl;
+    document.body.style.setProperty("--bg-image", `url(${newUrl})`);
+    toggleBackgroundType(true);
+}
 
 // Open IndexedDB database
 function openDatabase() {
@@ -33,7 +46,7 @@ async function saveImageToIndexedDB(imageBlob, isRandom) {
         const transaction = db.transaction(storeName, "readwrite");
         const store = transaction.objectStore(storeName);
 
-        store.put(imageBlob, "backgroundImage"); // Save Blob
+        store.put(imageBlob, "backgroundImage");
         store.put(new Date().toISOString(), timestampKey);
         store.put(isRandom ? "random" : "upload", imageTypeKey);
 
@@ -82,20 +95,9 @@ async function clearImageFromIndexedDB() {
 document.getElementById("imageUpload").addEventListener("change", function (event) {
     const file = event.target.files[0];
     if (file) {
-        const imageUrl = URL.createObjectURL(file); // Create temporary Blob URL
-        const image = new Image();
-
-        image.onload = function () {
-            document.body.style.setProperty("--bg-image", `url(${imageUrl})`);
-            saveImageToIndexedDB(file, false)
-                .then(() => {
-                    toggleBackgroundType(true);
-                    URL.revokeObjectURL(imageUrl); // Clean up memory
-                })
-                .catch(error => console.error(error));
-        };
-
-        image.src = imageUrl;
+        saveImageToIndexedDB(file, false)
+            .then(() => setBackground(file))
+            .catch(error => console.error(error));
     }
 });
 
@@ -110,13 +112,9 @@ async function applyRandomImage(showConfirmation = true) {
     }
     try {
         const response = await fetch(RANDOM_IMAGE_URL);
-        const blob = await response.blob(); // Get Blob from response
-        const imageUrl = URL.createObjectURL(blob);
-
-        document.body.style.setProperty("--bg-image", `url(${imageUrl})`);
+        const blob = await response.blob();
         await saveImageToIndexedDB(blob, true);
-        toggleBackgroundType(true);
-        setTimeout(() => URL.revokeObjectURL(imageUrl), 2000); // Delay URL revocation
+        setBackground(blob);
     } catch (error) {
         console.error("Error fetching random image:", error);
     }
@@ -134,32 +132,22 @@ function checkAndUpdateImage() {
             const now = new Date();
             const lastUpdate = new Date(savedTimestamp);
 
-            // No image or invalid data
             if (!blob || !savedTimestamp || isNaN(lastUpdate)) {
                 toggleBackgroundType(false);
                 return;
             }
 
-            // Create a new Blob URL dynamically
-            const imageUrl = URL.createObjectURL(blob);
-
             if (imageType === "upload") {
-                document.body.style.setProperty("--bg-image", `url(${imageUrl})`);
-                toggleBackgroundType(true);
+                setBackground(blob);
                 return;
             }
 
             if (lastUpdate.toDateString() !== now.toDateString()) {
-                // Refresh random image if a new day
                 applyRandomImage(false);
             } else {
-                // Reapply the saved random image
-                document.body.style.setProperty("--bg-image", `url(${imageUrl})`);
-                toggleBackgroundType(true);
+                setBackground(blob);
             }
 
-            // Clean up the Blob URL after setting the background
-            setTimeout(() => URL.revokeObjectURL(imageUrl), 1500);
         })
         .catch((error) => {
             console.error("Error loading image details:", error);
@@ -184,6 +172,10 @@ document.getElementById("clearImage").addEventListener("click", async function (
         if (await confirmPrompt(confirmationMessage)) {
             try {
                 await clearImageFromIndexedDB();
+                if (currentBgUrl) {
+                    URL.revokeObjectURL(currentBgUrl);
+                    currentBgUrl = null;
+                }
                 document.body.style.removeProperty("--bg-image");
                 toggleBackgroundType(false);
             } catch (error) {
@@ -194,8 +186,8 @@ document.getElementById("clearImage").addEventListener("click", async function (
         console.error(error);
     }
 });
+
 document.getElementById("randomImageTrigger").addEventListener("click", applyRandomImage);
 
 // Start image check on page load
 checkAndUpdateImage();
-// ------------------------ End of BG Image --------------------------

--- a/scripts/wallpaper.js
+++ b/scripts/wallpaper.js
@@ -17,13 +17,14 @@ let currentBgUrl = null;
 
 // To set background image using a Blob
 function setBackground(blob) {
-    if (currentBgUrl) {
-        URL.revokeObjectURL(currentBgUrl);
-    }
+    const previousUrl = currentBgUrl;
     const newUrl = URL.createObjectURL(blob);
     currentBgUrl = newUrl;
     document.body.style.setProperty("--bg-image", `url(${newUrl})`);
     toggleBackgroundType(true);
+    if (previousUrl) {
+        URL.revokeObjectURL(previousUrl);
+    }
 }
 
 // Open IndexedDB database

--- a/style.css
+++ b/style.css
@@ -3676,6 +3676,11 @@ input:checked + .toggle:before {
 	opacity: 0.9;
 }
 
+.shortcutSettingsEntry input::placeholder {
+	color: var(--textColorDark-blue);
+	opacity: 0.6;
+}
+
 .shortcutInputRow {
     display: flex;
     align-items: center;
@@ -3683,7 +3688,7 @@ input:checked + .toggle:before {
 }
 
 .shortcutInputRow:last-child {
-	margin-top: 1px;
+	margin-top: 2px;
 }
 
 .shortcutInputRow svg {


### PR DESCRIPTION
Fixed wallpaper disappearing on load due to blob URL being revoked too early

Closes #169 
Supersedes #206 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
This PR fixes a bug where wallpapers could disappear on load because a background blob URL was revoked too early. The change ensures the old object URL is revoked only after a new one has been created and applied, preventing the race condition that made wallpaper images unavailable. This closes issue #169 and supersedes PR #206.

## Changes
**scripts/wallpaper.js**
- Added module-level `currentBgUrl` to track the active background object URL.
- Introduced `setBackground(blob)` helper that:
  - Creates a new object URL, applies it to `--bg-image` and `data-bg`, then revokes the previous object URL (revocation occurs after the new URL is set).
  - Updates `currentBgUrl`.
- Refactored all background-setting flows (user uploads, fetched random images, and IndexedDB restoration) to use `setBackground()` instead of creating ad-hoc `URL.createObjectURL` and manually revoking URLs.
- Random-image fetch flow now converts responses to blobs, saves them to IndexedDB, and applies them via `setBackground()` (removed previous delayed-revocation logic).
- On restore from IndexedDB, applies stored blobs via `setBackground()` and re-fetches daily random images when the stored timestamp is not from the current day.
- Clear-background flow now revokes and nulls `currentBgUrl` before removing the `--bg-image` CSS property and switching to color mode.
- Minor reordering of listener wiring and the initial `checkAndUpdateImage()` call to align with the refactored lifecycle.

**CHANGELOG.md**
- Added an [Unreleased] → Fixed entry documenting the wallpaper disappearance fix.

**manifest.json / manifest(firefox).json**
- No version bump in these files in this branch (both remain at 3.3.504 in the repository snapshot).

**style.css**
- Added placeholder styling rule for inputs in shortcut settings: `.shortcutSettingsEntry input::placeholder`.
- Adjusted spacing for `.shortcutInputRow:last-child`.

## Problem Solved
Fixes issue #169: prevents automatic removal of user-set wallpapers by ensuring object URLs are revoked only after a new background has been applied. Wallpapers should now persist across browser sessions and days until changed by the user or the extension is reset/uninstalled.

## Impact
- No exported/public API changes; changes are internal to the wallpaper lifecycle management.
- Review effort: Medium (behavior-critical fix affecting image lifecycle, persistence, and IndexedDB interactions).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->