### PR TITLE
feat: Added support for right-click to access AI Tools settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project partially follows [Semantic Versioning](https://semver.org/spec
 - Prevented weather condition and shortcut icons from being color-inverted in dark mode ([@prem-k-r](https://github.com/prem-k-r)) ([#191](https://github.com/prem-k-r/MaterialYouNewTab/pull/191))
 - Improved fallback behavior of shortcut icons to first-letter icons when custom icons fail to load or when offline ([@prem-k-r](https://github.com/prem-k-r)) ([#187](https://github.com/prem-k-r/MaterialYouNewTab/pull/187/))
 - Disabled dragging for weather and location icons ([@anndiy](https://github.com/anndiy)) ([#183](https://github.com/prem-k-r/MaterialYouNewTab/pull/183))
+- Added support for right-click to access AI Tools settings ([@prem-k-r](https://github.com/prem-k-r)) ([#210](https://github.com/prem-k-r/MaterialYouNewTab/pull/210/))
 
 ### Fixed
 

--- a/index.html
+++ b/index.html
@@ -1493,7 +1493,8 @@
                                         <div class="ttcont" id="newQuoteOnRefreshToggle">
                                             <div class="texts">
                                                 <div class="bigText" id="newQuoteOnRefreshText">Daily Quote</div>
-                                                <div class="infoText" id="newQuoteOnRefreshInfo">Show one quote per day instead of refreshing each time</div>
+                                                <div class="infoText" id="newQuoteOnRefreshInfo">Show one quote per day
+                                                    instead of refreshing each time</div>
                                             </div>
                                             <label class="switch">
                                                 <input id="newQuoteOnRefreshCheckbox" type="checkbox">
@@ -1940,8 +1941,7 @@
                         <div class="rightButtons">
                             <button id="newShortcutButton">
                                 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
-                                    <path
-                                        d="M3 13h8v8h2v-8h8v-2h-8V3h-2v8H3z" />
+                                    <path d="M3 13h8v8h2v-8h8v-2h-8V3h-2v8H3z" />
                                 </svg>
                             </button>
                             <button id="resetButton">

--- a/manifest(firefox).json
+++ b/manifest(firefox).json
@@ -1,7 +1,7 @@
 {
 	"manifest_version": 2,
 	"name": "MYNT: Material You New Tab",
-	"version": "3.3.504",
+	"version": "3.3.510",
 	"description": "A Simple New Tab (browser's home page) inspired by Google's 'Material You' design.",
 	"permissions": [
 		"search",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"manifest_version": 3,
 	"name": "MYNT: Material You New Tab",
-	"version": "3.3.504",
+	"version": "3.3.510",
 	"description": "A Simple New Tab (browser's home page) inspired by Google's 'Material You' design.",
 	"permissions": ["search"],
 	"optional_permissions": ["bookmarks", "favicon"],

--- a/scripts/ai-tools.js
+++ b/scripts/ai-tools.js
@@ -358,6 +358,15 @@ document.addEventListener("DOMContentLoaded", function () {
     // AI Tools icon click handler
     aiToolsIcon.addEventListener("click", toggleAITools);
 
+    // AI Tools icon right-click handler
+    aiToolsIcon.addEventListener("contextmenu", function (e) {
+        e.preventDefault();
+        e.stopPropagation();
+        showAIToolsSettings();
+        // Prevent the menu from closing when right-clicking
+        e.stopImmediatePropagation();
+    });
+
     // AI Tools edit button click handler
     aiToolsEditButton.addEventListener("click", function (e) {
         e.preventDefault();
@@ -366,7 +375,11 @@ document.addEventListener("DOMContentLoaded", function () {
     });
 
     // Close button in settings modal
-    closeAISettingsBtn.addEventListener("click", closeAIToolsSettings);
+    closeAISettingsBtn.addEventListener("click", function (e) {
+        e.preventDefault();
+        e.stopPropagation();
+        closeAIToolsSettings();
+    });
 
     // Reset button in settings modal
     resetAISettingsBtn.addEventListener("click", function () {
@@ -423,7 +436,10 @@ document.addEventListener("DOMContentLoaded", function () {
     });
 
     // Save button in settings modal
-    saveAISettingsBtn.addEventListener("click", function () {
+    saveAISettingsBtn.addEventListener("click", function (e) {
+        e.preventDefault();
+        e.stopPropagation();
+
         const newSettings = [];
         const toolOptions = document.querySelectorAll(".ai-tool-option");
 
@@ -482,9 +498,10 @@ document.addEventListener("DOMContentLoaded", function () {
         aiToolsEditField.classList.add("inactive");
     }
 
-    // Collapse when clicking outside toolsCont
+    // Collapse when clicking outside toolsCont (but not if settings modal is open)
     document.addEventListener("click", (event) => {
-        if (!aiToolName.contains(event.target) && aiToolName.style.display === "flex") {
+        const isSettingsModalOpen = aiToolsSettingsModal.style.display === "block";
+        if (!aiToolName.contains(event.target) && aiToolName.style.display === "flex" && !isSettingsModalOpen) {
             toggleAITools();
         }
     });

--- a/scripts/ai-tools.js
+++ b/scripts/ai-tools.js
@@ -198,8 +198,8 @@ function generateAIToolsForm(settings) {
                 <label for="setting_${toolId}">${toolLabel}</label>
             </div>
             <div class="ai-tool-reorder">
-                <button type="button" class="reorder-up" ${index === 0 ? "disabled" : ""}>▲</button>
-                <button type="button" class="reorder-down" ${index === settings.length - 1 ? "disabled" : ""}>▼</button>
+                <button type="button" class="reorder-up" ${index === 0 ? "disabled" : ""}><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path fill="currentColor" d="M10.974 8.192a1.465 1.465 0 0 1 2.07 0l5.527 5.524a1.465 1.465 0 1 1-2.073 2.072l-4.49-4.488-4.488 4.49a1.465 1.465 0 1 1-2.073-2.072Z"/></svg></button>
+                <button type="button" class="reorder-down" ${index === settings.length - 1 ? "disabled" : ""}><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path fill="currentColor" d="M13.047 15.809a1.47 1.47 0 0 1-2.076 0l-5.54-5.54a1.47 1.47 0 1 1 2.077-2.076l4.501 4.5 4.501-4.5a1.469 1.469 0 0 1 2.078 2.076l-5.54 5.54z"/></svg></button>
             </div>
         `;
         aiToolsForm.appendChild(toolOption);

--- a/scripts/ai-tools.js
+++ b/scripts/ai-tools.js
@@ -363,8 +363,6 @@ document.addEventListener("DOMContentLoaded", function () {
         e.preventDefault();
         e.stopPropagation();
         showAIToolsSettings();
-        // Prevent the menu from closing when right-clicking
-        e.stopImmediatePropagation();
     });
 
     // AI Tools edit button click handler

--- a/scripts/languages.js
+++ b/scripts/languages.js
@@ -401,7 +401,7 @@ function applyLanguage(lang) {
     quotesText.style.fontFamily = commonFontStack;
 
     // Save the selected language in localStorage
-    document.documentElement.lang = currentLanguage;
+    document.documentElement.lang = lang;
     saveLanguageStatus("selectedLanguage", lang);
 }
 

--- a/scripts/shortcuts.js
+++ b/scripts/shortcuts.js
@@ -8,11 +8,11 @@ document.addEventListener("DOMContentLoaded", function () {
     // Constants
     const MAX_SHORTCUTS = 50;
     const PLACEHOLDER = {
-        get name()      { return translations[currentLanguage]?.shortcutDefaultName || translations["en"].shortcutDefaultName; },
+        get name() { return translations[currentLanguage]?.shortcutDefaultName || translations["en"].shortcutDefaultName; },
         url: "https://github.com/prem-k-r/MaterialYouNewTab",
-        get inputName() { return translations[currentLanguage]?.shortcutInputName   || translations["en"].shortcutInputName; },
-        get inputUrl()  { return translations[currentLanguage]?.shortcutInputUrl    || translations["en"].shortcutInputUrl; },
-        get inputIcon() { return translations[currentLanguage]?.shortcutInputIcon   || translations["en"].shortcutInputIcon; },
+        get inputName() { return translations[currentLanguage]?.shortcutInputName || translations["en"].shortcutInputName; },
+        get inputUrl() { return translations[currentLanguage]?.shortcutInputUrl || translations["en"].shortcutInputUrl; },
+        get inputIcon() { return translations[currentLanguage]?.shortcutInputIcon || translations["en"].shortcutInputIcon; },
     };
 
     // DOM Elements
@@ -820,17 +820,17 @@ document.addEventListener("DOMContentLoaded", function () {
                 try {
                     localStorage.setItem(`shortcutIcon${index}`, item.icon || "");
                 } catch (iconError) {
-                        if (iconError.name === "QuotaExceededError" || iconError.code === 22) {
-                            // Remove icon due to quota
-                            localStorage.removeItem(`shortcutIcon${index}`);
-                            const entry = entries[index];
-                            if (entry) entry.querySelector(".iconURL").value = "";
-                            item.icon = "";
-                        } else {
-                            throw iconError;
-                        }
+                    if (iconError.name === "QuotaExceededError" || iconError.code === 22) {
+                        // Remove icon due to quota
+                        localStorage.removeItem(`shortcutIcon${index}`);
+                        const entry = entries[index];
+                        if (entry) entry.querySelector(".iconURL").value = "";
+                        item.icon = "";
+                    } else {
+                        throw iconError;
                     }
-                });
+                }
+            });
 
             shortcutsCache = newOrder;
             renderAllShortcuts(newOrder);

--- a/style.css
+++ b/style.css
@@ -2901,12 +2901,12 @@ body[data-bg="wallpaper"] .aiToolsCont .toolsCont a {
 #aiToolsForm .ai-tool-reorder button {
 	color: var(--darkColor-blue);
 	background-color: var(--bg-color-blue);
-	border: none;
+	border: 1px solid color-mix(in srgb, var(--darkColor-blue) 20%, transparent);
 	border-radius: 20%;
 	width: 24px;
 	height: 24px;
 	padding: 1px;
-	opacity: 0.9;
+	opacity: 0.8;
 	cursor: pointer;
 	display: flex;
 	justify-content: center;
@@ -2915,6 +2915,7 @@ body[data-bg="wallpaper"] .aiToolsCont .toolsCont a {
 
 #aiToolsForm .ai-tool-reorder button:hover {
 	color: var(--darkerColor-blue);
+	border: 1px solid color-mix(in srgb, var(--darkColor-blue) 50%, transparent);
 }
 
 #aiToolsForm .ai-tool-reorder button:active {

--- a/style.css
+++ b/style.css
@@ -2915,7 +2915,7 @@ body[data-bg="wallpaper"] .aiToolsCont .toolsCont a {
 
 #aiToolsForm .ai-tool-reorder button:hover {
 	color: var(--darkerColor-blue);
-	border: 1px solid color-mix(in srgb, var(--darkColor-blue) 50%, transparent);
+	border-color: color-mix(in srgb, var(--darkColor-blue) 50%, transparent);
 }
 
 #aiToolsForm .ai-tool-reorder button:active {

--- a/style.css
+++ b/style.css
@@ -236,7 +236,9 @@ html:has(
 	& #darkTheme,
 	& .favicon,
 	& #wIcon,
-	&:not(:has(#adaptiveIconToggle:checked)) .shortcutLogoContainer img[data-icon-type="default"] {
+	&:not(:has(#adaptiveIconToggle:checked))
+		.shortcutLogoContainer
+		img[data-icon-type="default"] {
 		filter: invert(1) hue-rotate(180deg);
 		-webkit-filter: invert(1) hue-rotate(180deg);
 	}
@@ -276,7 +278,9 @@ body[data-bg="wallpaper"][sysTheme="systemDark"]:has(
 	& #darkTheme,
 	& .favicon,
 	& #wIcon,
-	&:not(:has(#adaptiveIconToggle:checked)) .shortcutLogoContainer img[data-icon-type="default"] {
+	&:not(:has(#adaptiveIconToggle:checked))
+		.shortcutLogoContainer
+		img[data-icon-type="default"] {
 		filter: invert(1) hue-rotate(180deg);
 		-webkit-filter: invert(1) hue-rotate(180deg);
 	}
@@ -1685,7 +1689,6 @@ html[lang="ta"] .digiclock {
 	border-bottom: 1px solid rgba(0, 0, 0, 0.06);
 }
 
-
 .clock-hidden-left {
 	display: none;
 }
@@ -2572,7 +2575,10 @@ body[data-bg="wallpaper"] .shortcuts .shortcut-name {
 }
 
 /* Adaptive Icons styling */
-.adaptive-icons .shortcuts .shortcutLogoContainer img[data-icon-type="default"] {
+.adaptive-icons
+	.shortcuts
+	.shortcutLogoContainer
+	img[data-icon-type="default"] {
 	height: calc(100% * 0.7071) !important;
 	width: calc(100% * 0.7071) !important;
 	filter: grayscale(1);
@@ -2584,12 +2590,16 @@ html:has(.themeSegment[data-active="dark"]):not(:has(#darkTheme:checked))
 	.shortcuts
 	.shortcutLogoContainer
 	img[data-icon-type="default"],
-html:has(body[sysTheme="systemDark"] .themeSegment[data-active="system"]):not(:has(#darkTheme:checked))
+html:has(body[sysTheme="systemDark"] .themeSegment[data-active="system"]):not(
+		:has(#darkTheme:checked)
+	)
 	.adaptive-icons
 	.shortcuts
 	.shortcutLogoContainer
 	img[data-icon-type="default"],
-body[data-bg="wallpaper"]:has(.themeSegment[data-active="dark"]):not(:has(#darkTheme:checked))
+body[data-bg="wallpaper"]:has(.themeSegment[data-active="dark"]):not(
+		:has(#darkTheme:checked)
+	)
 	.adaptive-icons
 	.shortcutLogoContainer
 	img[data-icon-type="default"],
@@ -2603,34 +2613,48 @@ body[data-bg="wallpaper"][sysTheme="systemDark"]:has(
 }
 
 .shortcutLogoContainer img[data-icon-type="custom"] {
-    filter: none !important;
-    mix-blend-mode: normal !important;
+	filter: none !important;
+	mix-blend-mode: normal !important;
 	border-radius: 10% !important;
 }
 
 html:has(.themeSegment[data-active="dark"]):not(:has(#darkTheme:checked))
-    .shortcuts .shortcutLogoContainer img[data-icon-type="custom"],
-html:has(body[sysTheme="systemDark"] .themeSegment[data-active="system"]):not(:has(#darkTheme:checked))
-    .shortcuts .shortcutLogoContainer img[data-icon-type="custom"],
-body[data-bg="wallpaper"]:has(.themeSegment[data-active="dark"]):not(:has(#darkTheme:checked))
-    .shortcuts .shortcutLogoContainer img[data-icon-type="custom"],
-body[data-bg="wallpaper"][sysTheme="systemDark"]:has(.themeSegment[data-active="system"]):not(:has(#darkTheme:checked))
-    .shortcuts .shortcutLogoContainer img[data-icon-type="custom"] {
-    filter: invert(1) hue-rotate(180deg) !important;
-    mix-blend-mode: normal !important;
+	.shortcuts
+	.shortcutLogoContainer
+	img[data-icon-type="custom"],
+html:has(body[sysTheme="systemDark"] .themeSegment[data-active="system"]):not(
+		:has(#darkTheme:checked)
+	)
+	.shortcuts
+	.shortcutLogoContainer
+	img[data-icon-type="custom"],
+body[data-bg="wallpaper"]:has(.themeSegment[data-active="dark"]):not(
+		:has(#darkTheme:checked)
+	)
+	.shortcuts
+	.shortcutLogoContainer
+	img[data-icon-type="custom"],
+body[data-bg="wallpaper"][sysTheme="systemDark"]:has(
+		.themeSegment[data-active="system"]
+	):not(:has(#darkTheme:checked))
+	.shortcuts
+	.shortcutLogoContainer
+	img[data-icon-type="custom"] {
+	filter: invert(1) hue-rotate(180deg) !important;
+	mix-blend-mode: normal !important;
 }
 
 .adaptive-icons .shortcuts .shortcutLogoContainer img[data-icon-type="custom"] {
-    height: calc(100% * 0.7071) !important;
-    width: calc(100% * 0.7071) !important;
+	height: calc(100% * 0.7071) !important;
+	width: calc(100% * 0.7071) !important;
 }
 
 .adaptive-icons .shortcuts .shortcutLogoContainer img[data-icon-type="letter"] {
 	height: 100% !important;
 	width: 100% !important;
 	filter: none !important;
-    mix-blend-mode: normal !important;
-} 
+	mix-blend-mode: normal !important;
+}
 
 /* ----------end of Shortcuts----------------- */
 
@@ -2875,16 +2899,15 @@ body[data-bg="wallpaper"] .aiToolsCont .toolsCont a {
 }
 
 #aiToolsForm .ai-tool-reorder button {
-	background: color-mix(in srgb, var(--whitishColor-blue) 60%, transparent);
 	color: var(--darkColor-blue);
-	border: 1px solid var(--darkColor-blue);
-	border-radius: 6px;
-	width: 26px;
-	height: 22px;
-	font-size: 0.8rem;
-	line-height: 1;
+	background-color: var(--bg-color-blue);
+	border: none;
+	border-radius: 20%;
+	width: 24px;
+	height: 24px;
+	padding: 1px;
+	opacity: 0.9;
 	cursor: pointer;
-	padding: 0;
 	display: flex;
 	justify-content: center;
 	align-items: center;
@@ -2892,7 +2915,6 @@ body[data-bg="wallpaper"] .aiToolsCont .toolsCont a {
 
 #aiToolsForm .ai-tool-reorder button:hover {
 	color: var(--darkerColor-blue);
-	border-color: var(--darkerColor-blue);
 }
 
 #aiToolsForm .ai-tool-reorder button:active {
@@ -2905,6 +2927,7 @@ body[data-bg="wallpaper"] .aiToolsCont .toolsCont a {
 }
 
 #aiToolsForm .ai-tool-reorder button:disabled:hover {
+	color: var(--darkColor-blue);
 	transform: none;
 }
 
@@ -3542,7 +3565,9 @@ input:checked + .toggle:before {
 	padding: 8px;
 	border-radius: 7px;
 	cursor: pointer;
-	transition: background-color 0.3s ease, fill 0.3s ease;
+	transition:
+		background-color 0.3s ease,
+		fill 0.3s ease;
 }
 
 #resetButton:hover,
@@ -3655,11 +3680,13 @@ input:checked + .toggle:before {
 }
 
 .shortcutSettingsEntry input:hover {
-    animation: clipText 0s 150ms forwards;
+	animation: clipText 0s 150ms forwards;
 }
 
 @keyframes clipText {
-    to { text-overflow: clip; }
+	to {
+		text-overflow: clip;
+	}
 }
 
 .shortcutSettingsEntry .shortcutName {
@@ -3677,9 +3704,9 @@ input:checked + .toggle:before {
 }
 
 .shortcutInputRow {
-    display: flex;
-    align-items: center;
-    gap: 4px;
+	display: flex;
+	align-items: center;
+	gap: 4px;
 }
 
 .shortcutInputRow:last-child {
@@ -3687,15 +3714,15 @@ input:checked + .toggle:before {
 }
 
 .shortcutInputRow svg {
-    flex-shrink: 0;
-    opacity: 0.5;
-    color: var(--textColorDark-blue);
-    pointer-events: none;
+	flex-shrink: 0;
+	opacity: 0.5;
+	color: var(--textColorDark-blue);
+	pointer-events: none;
 }
 
 .shortcutInputRow input {
-    flex: 1;
-    min-width: 0;
+	flex: 1;
+	min-width: 0;
 }
 
 /* Drag and drop styles */
@@ -5175,6 +5202,15 @@ body[data-bg="wallpaper"] .dropdown-content {
 	box-shadow: inset 0 0 0 1px var(--darkerColor-dark);
 }
 
+.black-theme #aiToolsForm .ai-tool-option input[type="checkbox"] {
+	accent-color: #212121;
+}
+
+.black-theme #aiToolsForm .ai-tool-reorder button,
+.black-theme #aiToolsForm .ai-tool-reorder button:disabled:hover {
+	color: #909090;
+}
+
 .black-theme .favicon {
 	filter: drop-shadow(0 0 2px rgba(255, 255, 255, 0.3));
 }
@@ -5290,7 +5326,7 @@ body[data-bg="wallpaper"] .dropdown-content {
 }
 
 .black-theme #resetButton:hover,
-.black-theme #newShortcutButton:hover{
+.black-theme #newShortcutButton:hover {
 	fill: #e4e4e4;
 	background: #282828;
 }


### PR DESCRIPTION
Add a contextmenu (right-click) handler on the AI Tools icon to open the settings modal and suppress the default context menu. Prevent default/stop propagation on settings modal Close and Save buttons to avoid accidental closing or unwanted event bubbling. Update outside-click collapse logic to ignore clicks when the settings modal is open so the tools panel doesn't close while configuring settings.

## Behavior
- Right-click on the AI Tools button to open the AI settings menu
- When the AI tools menu is expanded and we right-click to edit, the menu stays open
- Clicking save or close on the AI settings modal keeps the expanded menu open
- Prevents unwanted collapse when interacting with the settings interface

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Implementation Details

This PR adds right-click (contextmenu) support to the AI Tools icon and adjusts modal/panel interaction to prevent unintended collapse. Key changes:

scripts/ai-tools.js
- Added a `contextmenu` listener on the AI Tools icon that calls `preventDefault()` and `stopPropagation()`, then opens the AI Tools settings modal (suppresses the browser context menu).
- Ensured the AI Tools edit button opens the settings modal with `preventDefault()`/`stopPropagation()`.
- Updated the settings modal Close and Save button handlers to call `preventDefault()` and `stopPropagation()` before performing their existing behavior (close or save/apply/close), preventing accidental close or event bubbling.
- Kept the settings overlay click-to-close behavior.
- Updated the document-level outside-click collapse handler to check whether the settings modal is open (modal display === "block") and avoid collapsing the AI Tools panel while settings are open.
- Preserved existing save/apply/reset logic and reorder animations for AI tool entries; event handlers for reorder buttons and form interactions remain intact.
- Replaced text arrow labels for AI tools reorder buttons with inline SVG icons in the settings form.

style.css
- Updated AI Tools modal reorder-button styling: smaller transparent circular button (~17x17), centered flex layout, no border, explicit hover/disabled styling.
- Adjusted dark-theme overrides for related controls (checkbox `accent-color` and reorder button text/icon color).
- Other selector nesting and adaptive icon styling refinements; minor formatting-only CSS tweaks elsewhere.

CHANGELOG.md
- Added an entry under "Improved" documenting "right-click access to AI Tools settings."

Other updates
- index.html: minor text formatting (line break) and SVG markup whitespace change.
- manifest.json and manifest(firefox).json: bumped version from 3.3.504 → 3.3.510.
- scripts/languages.js: `applyLanguage(lang)` now sets `document.documentElement.lang` using the incoming `lang` argument.
- scripts/shortcuts.js: formatting-only refactors for localized placeholder getters and a reformat of the QuotaExceededError handling block.

## Behavior Changes

- Right-clicking the AI Tools icon opens the AI Tools settings modal instead of the browser context menu.
- If the AI Tools menu is expanded, opening settings (via right-click or Edit) no longer closes the menu; the panel remains expanded while settings are open.
- Clicking Save or Close in the settings modal does not collapse the expanded AI Tools menu.
- Interacting with the settings UI (including reorder and reset actions) will not trigger the outside-click collapse logic for the tools panel.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/prem-k-r/MaterialYouNewTab/pull/210)

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/prem-k-r/MaterialYouNewTab/pull/210)

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/prem-k-r/MaterialYouNewTab/pull/210)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->